### PR TITLE
Add EFI fallback file

### DIFF
--- a/SPECS/grub.spec
+++ b/SPECS/grub.spec
@@ -26,10 +26,10 @@
 %global grubeficdname gcdx64.efi
 %endif
 
-%global grubefibootname bootx64.efi
+%global grubefibootname BOOTX64.EFI
 
 %global efidir xenserver
-%global efibootdir boot
+%global efibootdir BOOT
 
 %endif
 
@@ -331,7 +331,7 @@ fi
 %config(noreplace) %{_sysconfdir}/%{name}-efi.cfg
 %dir /boot/efi/EFI/%{efidir}
 %attr(0755,root,root) /boot/efi/EFI/%{efidir}/*.efi
-%attr(0755,root,root) /boot/efi/EFI/%{efibootdir}/*.efi
+%attr(0755,root,root) /boot/efi/EFI/%{efibootdir}/%{grubefibootname}
 %ghost %config(noreplace) /boot/efi/EFI/%{efidir}/grub.cfg
 %doc COPYING
 %endif
@@ -389,7 +389,7 @@ fi
 
 %changelog
 * Tue Jun 29 2021 Benjamin Reis <benjamin.reis@vates.fr> - 2.02-3.0.0.1
-- Add EFI fallback file (`EFI/boot/bootx64.efi`) for when all boot entries fail
+- Add EFI fallback file (`EFI/BOOT/BOOTX64.EFI`) for when all boot entries fail
 
 * Mon Sep 23 2019 Ross Lagerwall <ross.lagerwall@citrix.com> - 2.02-3.0.0
 - CA-322681: ns8250: Wait a short while before draining the input buffer

--- a/SPECS/grub.spec
+++ b/SPECS/grub.spec
@@ -38,7 +38,7 @@
 Name:           grub
 Epoch:          1
 Version:        2.02
-Release:        3.0.0%{?dist}
+Release:        3.0.0.1%{?dist}
 Summary:        Bootloader with support for Linux, Multiboot and more
 
 Group:          System Environment/Base
@@ -388,5 +388,8 @@ fi
 %{_mandir}/man8/*
 
 %changelog
+* Tue Jun 29 2021 Benjamin Reis <benjamin.reis@vates.fr> - 2.02-3.0.0.1
+- Add EFI fallback file (`EFI/boot/bootx64.efi`) for when all boot entries fail
+
 * Mon Sep 23 2019 Ross Lagerwall <ross.lagerwall@citrix.com> - 2.02-3.0.0
 - CA-322681: ns8250: Wait a short while before draining the input buffer

--- a/SPECS/grub.spec
+++ b/SPECS/grub.spec
@@ -230,6 +230,7 @@ install -m 755 %{grubefiname} $RPM_BUILD_ROOT/boot/efi/EFI/%{efidir}/%{grubefina
 install -m 755 %{grubeficdname} $RPM_BUILD_ROOT/boot/efi/EFI/%{efidir}/%{grubeficdname}
 # XCP-ng: Add fallback for when all boot entries fail
 # (buggy UEFI implementation, NVRAM error, user error in configuring boot entries, etc... could all cause this)
+# It's a copy of grubx64.efi so the binary will still look at its cfg file in `EFI/xenserver`
 mkdir -p $RPM_BUILD_ROOT/boot/efi/EFI/%{efibootdir}/
 install -m 755 %{grubefiname} $RPM_BUILD_ROOT/boot/efi/EFI/%{efibootdir}/%{grubefibootname}
 popd
@@ -331,6 +332,7 @@ fi
 %config(noreplace) %{_sysconfdir}/%{name}-efi.cfg
 %dir /boot/efi/EFI/%{efidir}
 %attr(0755,root,root) /boot/efi/EFI/%{efidir}/*.efi
+%dir /boot/efi/EFI/%{efibootdir}
 %attr(0755,root,root) /boot/efi/EFI/%{efibootdir}/%{grubefibootname}
 %ghost %config(noreplace) /boot/efi/EFI/%{efidir}/grub.cfg
 %doc COPYING

--- a/SPECS/grub.spec
+++ b/SPECS/grub.spec
@@ -26,7 +26,10 @@
 %global grubeficdname gcdx64.efi
 %endif
 
+%global grubefibootname bootx64.efi
+
 %global efidir xenserver
+%global efibootdir boot
 
 %endif
 
@@ -225,6 +228,8 @@ do
 done
 install -m 755 %{grubefiname} $RPM_BUILD_ROOT/boot/efi/EFI/%{efidir}/%{grubefiname}
 install -m 755 %{grubeficdname} $RPM_BUILD_ROOT/boot/efi/EFI/%{efidir}/%{grubeficdname}
+# Add fallback for when all boot entries fail (buggy UEFI implementation, NVRAM error, user error in configuring boot entries, etc... could all cause this)
+install -m 755 %{grubefiname} $RPM_BUILD_ROOT/boot/efi/EFI/%{efibootdir}/%{grubefibootname}
 popd
 %endif
 

--- a/SPECS/grub.spec
+++ b/SPECS/grub.spec
@@ -228,7 +228,9 @@ do
 done
 install -m 755 %{grubefiname} $RPM_BUILD_ROOT/boot/efi/EFI/%{efidir}/%{grubefiname}
 install -m 755 %{grubeficdname} $RPM_BUILD_ROOT/boot/efi/EFI/%{efidir}/%{grubeficdname}
-# Add fallback for when all boot entries fail (buggy UEFI implementation, NVRAM error, user error in configuring boot entries, etc... could all cause this)
+# XCP-ng: Add fallback for when all boot entries fail
+# (buggy UEFI implementation, NVRAM error, user error in configuring boot entries, etc... could all cause this)
+mkdir -p $RPM_BUILD_ROOT/boot/efi/EFI/%{efibootdir}/
 install -m 755 %{grubefiname} $RPM_BUILD_ROOT/boot/efi/EFI/%{efibootdir}/%{grubefibootname}
 popd
 %endif
@@ -329,6 +331,7 @@ fi
 %config(noreplace) %{_sysconfdir}/%{name}-efi.cfg
 %dir /boot/efi/EFI/%{efidir}
 %attr(0755,root,root) /boot/efi/EFI/%{efidir}/*.efi
+%attr(0755,root,root) /boot/efi/EFI/%{efibootdir}/*.efi
 %ghost %config(noreplace) /boot/efi/EFI/%{efidir}/grub.cfg
 %doc COPYING
 %endif


### PR DESCRIPTION
Some firmware needs to have a fallback efi binary in the EFI/boot directory and will fail to boot if not.
See: https://xcp-ng.org/forum/topic/4690/host-not-booting-after-install-uefi/

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>