### PR TITLE
Backport VLAN networking support

### DIFF
--- a/SOURCES/0001-net-ethernet-Fix-VLAN-networking-on-little-endian-sy.patch
+++ b/SOURCES/0001-net-ethernet-Fix-VLAN-networking-on-little-endian-sy.patch
@@ -1,0 +1,62 @@
+From e733d8d2e864ab9d61e7b9eaf24733ae3ef56e56 Mon Sep 17 00:00:00 2001
+From: Chad Kimes <chkimes@github.com>
+Date: Wed, 2 Mar 2022 14:21:22 -0500
+Subject: [PATCH 1/5] net/ethernet: Fix VLAN networking on little-endian
+ systems
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+VLAN configuration seems to have never worked on little-endian systems.
+This is likely because VLANTAG_IDENTIFIER is not byte-swapped before
+copying into the net buffer, nor is inf->vlantag. We can resolve this by
+using grub_cpu_to_be16{_compile_time}() and its inverse when copying
+VLAN info to/from the net buffer.
+
+Signed-off-by: Chad Kimes <chkimes@github.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Upstream patch: c216df4036b67e27defafd65543c075274709b37
+
+ grub-core/net/ethernet.c | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/grub-core/net/ethernet.c b/grub-core/net/ethernet.c
+index 4d7ceed6f..a9906338c 100644
+--- a/grub-core/net/ethernet.c
++++ b/grub-core/net/ethernet.c
+@@ -58,7 +58,7 @@ send_ethernet_packet (struct grub_net_network_level_interface *inf,
+   struct etherhdr *eth;
+   grub_err_t err;
+   grub_uint8_t etherhdr_size;
+-  grub_uint16_t vlantag_id = VLANTAG_IDENTIFIER;
++  grub_uint16_t vlantag_id = grub_cpu_to_be16_compile_time (VLANTAG_IDENTIFIER);
+ 
+   etherhdr_size = sizeof (*eth);
+   COMPILE_TIME_ASSERT (sizeof (*eth) + 4 < GRUB_NET_MAX_LINK_HEADER_SIZE);
+@@ -93,8 +93,9 @@ send_ethernet_packet (struct grub_net_network_level_interface *inf,
+                    (char *) nb->data + etherhdr_size - 6, 2);
+ 
+       /* Add the tag in the middle */
++      grub_uint16_t vlan = grub_cpu_to_be16 (inf->vlantag);
+       grub_memcpy ((char *) nb->data + etherhdr_size - 6, &vlantag_id, 2);
+-      grub_memcpy ((char *) nb->data + etherhdr_size - 4, (char *) &(inf->vlantag), 2);
++      grub_memcpy ((char *) nb->data + etherhdr_size - 4, &vlan, 2);
+     }
+ 
+   return inf->card->driver->send (inf->card, nb);
+@@ -118,9 +119,9 @@ grub_net_recv_ethernet_packet (struct grub_net_buff *nb,
+   /* Check if a vlan-tag is present. If so, the ethernet header is 4 bytes */
+   /* longer than the original one. The vlantag id is extracted and the header */
+   /* is reseted to the original size. */
+-  if (grub_get_unaligned16 (nb->data + etherhdr_size - 2) == VLANTAG_IDENTIFIER)
++  if (grub_get_unaligned16 (nb->data + etherhdr_size - 2) == grub_cpu_to_be16_compile_time (VLANTAG_IDENTIFIER))
+     {
+-      vlantag = grub_get_unaligned16 (nb->data + etherhdr_size);
++      vlantag = grub_be_to_cpu16 (grub_get_unaligned16 (nb->data + etherhdr_size));
+       etherhdr_size += 4;
+       /* Move eth type to the original position */
+       grub_memcpy((char *) nb->data + etherhdr_size - 6,
+-- 
+2.45.2
+

--- a/SOURCES/0002-net-net-Add-vlan-information-to-net_ls_addr-output.patch
+++ b/SOURCES/0002-net-net-Add-vlan-information-to-net_ls_addr-output.patch
@@ -1,0 +1,86 @@
+From 4531bd6bac28a83717fec6b42b11d63fc0158bd0 Mon Sep 17 00:00:00 2001
+From: Chad Kimes <chkimes@github.com>
+Date: Mon, 21 Mar 2022 17:29:15 -0400
+Subject: [PATCH 2/5] net/net: Add vlan information to net_ls_addr output
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Example output:
+  grub> net_ls_addr
+  efinet1 00:11:22:33:44:55 192.0.2.100 vlan100
+
+Signed-off-by: Chad Kimes <chkimes@github.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Upstream-patch: 98c299e540ec2942c2734c3e56cf586302d3eef0
+
+ grub-core/net/net.c | 19 ++++++++++++++++++-
+ include/grub/net.h  |  6 ++++++
+ 2 files changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/grub-core/net/net.c b/grub-core/net/net.c
+index 4d3eb5c1a..0a93f5931 100644
+--- a/grub-core/net/net.c
++++ b/grub-core/net/net.c
+@@ -781,6 +781,20 @@ grub_net_hwaddr_to_str (const grub_net_link_level_address_t *addr, char *str)
+   grub_printf (_("Unsupported hw address type %d\n"), addr->type);
+ }
+ 
++void
++grub_net_vlan_to_str (grub_uint16_t vlantag, char *str)
++{
++  str[0] = 0;
++
++  /* 12 bits are used to identify the vlan in 802.1Q. */
++  vlantag = vlantag & 0x0fff;
++
++  if (vlantag == 0)
++    return;
++
++  grub_snprintf (str, GRUB_NET_MAX_STR_VLAN_LEN, "vlan%u", vlantag);
++}
++
+ int
+ grub_net_hwaddr_cmp (const grub_net_link_level_address_t *a,
+ 		     const grub_net_link_level_address_t *b)
+@@ -1250,9 +1264,12 @@ grub_cmd_listaddrs (struct grub_command *cmd __attribute__ ((unused)),
+   {
+     char bufh[GRUB_NET_MAX_STR_HWADDR_LEN];
+     char bufn[GRUB_NET_MAX_STR_ADDR_LEN];
++    char bufv[GRUB_NET_MAX_STR_VLAN_LEN];
++
+     grub_net_hwaddr_to_str (&inf->hwaddress, bufh);
+     grub_net_addr_to_str (&inf->address, bufn);
+-    grub_printf ("%s %s %s\n", inf->name, bufh, bufn);
++    grub_net_vlan_to_str (inf->vlantag, bufv);
++    grub_printf ("%s %s %s %s\n", inf->name, bufh, bufn, bufv);
+   }
+   return GRUB_ERR_NONE;
+ }
+diff --git a/include/grub/net.h b/include/grub/net.h
+index 7ae4b6bd8..b2d044ceb 100644
+--- a/include/grub/net.h
++++ b/include/grub/net.h
+@@ -512,12 +512,18 @@ grub_net_addr_cmp (const grub_net_network_level_address_t *a,
+ 
+ #define GRUB_NET_MAX_STR_HWADDR_LEN (sizeof ("XX:XX:XX:XX:XX:XX"))
+ 
++/* Max VLAN id = 4094 */
++#define GRUB_NET_MAX_STR_VLAN_LEN (sizeof ("vlanXXXX"))
++
+ void
+ grub_net_addr_to_str (const grub_net_network_level_address_t *target,
+ 		      char *buf);
+ void
+ grub_net_hwaddr_to_str (const grub_net_link_level_address_t *addr, char *str);
+ 
++void
++grub_net_vlan_to_str (grub_uint16_t vlantag, char *str);
++
+ grub_err_t
+ grub_env_set_net_property (const char *intername, const char *suffix,
+                            const char *value, grub_size_t len);
+-- 
+2.45.2
+

--- a/SOURCES/0003-net-net-Add-net_set_vlan-command.patch
+++ b/SOURCES/0003-net-net-Add-net_set_vlan-command.patch
@@ -1,0 +1,139 @@
+From 6ba49b5b8fc56a904cae6f47217752ad0f908f96 Mon Sep 17 00:00:00 2001
+From: Chad Kimes <chkimes@github.com>
+Date: Mon, 21 Mar 2022 17:29:16 -0400
+Subject: [PATCH 3/5] net/net: Add net_set_vlan command
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Previously there was no way to set the 802.1Q VLAN identifier, despite
+support for vlantag in the net module. The only location vlantag was
+being populated was from PXE boot and only for Open Firmware hardware.
+This commit allows users to manually configure VLAN information for any
+interface.
+
+Example usage:
+  grub> net_ls_addr
+  efinet1 00:11:22:33:44:55 192.0.2.100
+  grub> net_set_vlan efinet1 100
+  grub> net_ls_addr
+  efinet1 00:11:22:33:44:55 192.0.2.100 vlan100
+  grub> net_set_vlan efinet1 0
+  efinet1 00:11:22:33:44:55 192.0.2.100
+
+Signed-off-by: Chad Kimes <chkimes@github.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Upstream-patch: 954c48b9c833d64b74ced1f27701af2ea5c6f55a
+
+ docs/grub.texi      | 20 ++++++++++++++++++++
+ grub-core/net/net.c | 41 ++++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 60 insertions(+), 1 deletion(-)
+
+diff --git a/docs/grub.texi b/docs/grub.texi
+index f8b4b3b21..f7fc6d784 100644
+--- a/docs/grub.texi
++++ b/docs/grub.texi
+@@ -5493,6 +5493,7 @@ This command is only available on AArch64 systems.
+ * net_ls_dns::                  List DNS servers
+ * net_ls_routes::               List routing entries
+ * net_nslookup::                Perform a DNS lookup
++* net_set_vlan::                Set vlan id on an interface
+ @end menu
+ 
+ 
+@@ -5669,6 +5670,25 @@ is given, use default list of servers.
+ @end deffn
+ 
+ 
++@node net_set_vlan
++@subsection net_set_vlan
++
++@deffn Command net_set_vlan @var{interface} @var{vlanid}
++Set the 802.1Q VLAN identifier on @var{interface} to @var{vlanid}. For example,
++to set the VLAN identifier on interface @samp{efinet1} to @samp{100}:
++
++@example
++net_set_vlan efinet1 100
++@end example
++
++The VLAN identifier can be removed by setting it to @samp{0}:
++
++@example
++net_set_vlan efinet1 0
++@end example
++@end deffn
++
++
+ @node Internationalisation
+ @chapter Internationalisation
+ 
+diff --git a/grub-core/net/net.c b/grub-core/net/net.c
+index 0a93f5931..2e34c1c4c 100644
+--- a/grub-core/net/net.c
++++ b/grub-core/net/net.c
+@@ -1176,6 +1176,42 @@ grub_cmd_addroute (struct grub_command *cmd __attribute__ ((unused)),
+     }
+ }
+ 
++static grub_err_t
++grub_cmd_setvlan (struct grub_command *cmd __attribute__ ((unused)),
++		  int argc, char **args)
++{
++  const char *vlan_string, *vlan_string_end;
++  unsigned long vlantag;
++  struct grub_net_network_level_interface *inter;
++
++  if (argc != 2)
++    return grub_error (GRUB_ERR_BAD_ARGUMENT, N_("two arguments expected"));
++
++  vlan_string = args[1];
++  vlantag = grub_strtoul (vlan_string, &vlan_string_end, 10);
++
++  if (*vlan_string == '\0' || *vlan_string_end != '\0')
++    return grub_error (GRUB_ERR_BAD_NUMBER,
++		       N_("non-numeric or invalid number `%s'"), vlan_string);
++
++  if (vlantag > 4094)
++    return grub_error (GRUB_ERR_OUT_OF_RANGE,
++		       N_("vlan id `%s' not in the valid range of 0-4094"),
++		       vlan_string);
++
++  FOR_NET_NETWORK_LEVEL_INTERFACES (inter)
++    {
++      if (grub_strcmp (inter->name, args[0]) != 0)
++	continue;
++
++      inter->vlantag = vlantag;
++      return GRUB_ERR_NONE;
++    }
++
++  return grub_error (GRUB_ERR_BAD_ARGUMENT,
++                     N_("network interface not found"));
++}
++
+ static void
+ print_net_address (const grub_net_network_level_netaddress_t *target)
+ {
+@@ -1892,7 +1928,7 @@ grub_net_search_config_file (char *config)
+ static struct grub_preboot *fini_hnd;
+ 
+ static grub_command_t cmd_addaddr, cmd_deladdr, cmd_addroute, cmd_delroute;
+-static grub_command_t cmd_lsroutes, cmd_lscards;
++static grub_command_t cmd_setvlan, cmd_lsroutes, cmd_lscards;
+ static grub_command_t cmd_lsaddr, cmd_slaac;
+ 
+ GRUB_MOD_INIT(net)
+@@ -1930,6 +1966,9 @@ GRUB_MOD_INIT(net)
+   cmd_delroute = grub_register_command ("net_del_route", grub_cmd_delroute,
+ 					N_("SHORTNAME"),
+ 					N_("Delete a network route."));
++  cmd_setvlan = grub_register_command ("net_set_vlan", grub_cmd_setvlan,
++				       N_("SHORTNAME VLANID"),
++				       N_("Set an interface's vlan id."));
+   cmd_lsroutes = grub_register_command ("net_ls_routes", grub_cmd_listroutes,
+ 					"", N_("list network routes"));
+   cmd_lscards = grub_register_command ("net_ls_cards", grub_cmd_listcards,
+-- 
+2.45.2
+

--- a/SOURCES/0004-kern-efi-efi-Print-VLAN-info-in-EFI-device-path.patch
+++ b/SOURCES/0004-kern-efi-efi-Print-VLAN-info-in-EFI-device-path.patch
@@ -1,0 +1,58 @@
+From 2bca85cb27b51792074771c43b22d7797c16abb8 Mon Sep 17 00:00:00 2001
+From: Chad Kimes <chkimes@github.com>
+Date: Mon, 21 Mar 2022 18:07:31 -0400
+Subject: [PATCH 4/5] kern/efi/efi: Print VLAN info in EFI device path
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+Signed-off-by: Chad Kimes <chkimes@github.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Upstream-patch: c143056a34b4ccc255a6ad4e96a5aa989d304760
+
+ grub-core/kern/efi/efi.c | 7 +++++++
+ include/grub/efi/api.h   | 9 +++++++++
+ 2 files changed, 16 insertions(+)
+
+diff --git a/grub-core/kern/efi/efi.c b/grub-core/kern/efi/efi.c
+index 8cff7be02..996e3c7c3 100644
+--- a/grub-core/kern/efi/efi.c
++++ b/grub-core/kern/efi/efi.c
+@@ -824,6 +824,13 @@ grub_efi_print_device_path (grub_efi_device_path_t *dp)
+ 			     sata->lun);
+ 	      }
+ 	      break;
++	    case GRUB_EFI_VLAN_DEVICE_PATH_SUBTYPE:
++	      {
++		grub_efi_vlan_device_path_t *vlan;
++		vlan = (grub_efi_vlan_device_path_t *) dp;
++		grub_printf ("/Vlan(%u)", vlan->vlan_id);
++	      }
++	      break;
+ 
+ 	    case GRUB_EFI_VENDOR_MESSAGING_DEVICE_PATH_SUBTYPE:
+ 	      dump_vendor_path ("Messaging",
+diff --git a/include/grub/efi/api.h b/include/grub/efi/api.h
+index f1a52210c..05db3b927 100644
+--- a/include/grub/efi/api.h
++++ b/include/grub/efi/api.h
+@@ -903,6 +903,15 @@ struct grub_efi_sata_device_path
+ } GRUB_PACKED;
+ typedef struct grub_efi_sata_device_path grub_efi_sata_device_path_t;
+ 
++#define GRUB_EFI_VLAN_DEVICE_PATH_SUBTYPE		20
++
++struct grub_efi_vlan_device_path
++{
++  grub_efi_device_path_t header;
++  grub_efi_uint16_t vlan_id;
++} GRUB_PACKED;
++typedef struct grub_efi_vlan_device_path grub_efi_vlan_device_path_t;
++
+ #define GRUB_EFI_VENDOR_MESSAGING_DEVICE_PATH_SUBTYPE	10
+ 
+ /* Media Device Path.  */
+-- 
+2.45.2
+

--- a/SOURCES/0005-net-drivers-efi-efinet-Configure-VLAN-from-UEFI-devi.patch
+++ b/SOURCES/0005-net-drivers-efi-efinet-Configure-VLAN-from-UEFI-devi.patch
@@ -1,0 +1,79 @@
+From 565e30569be94781567d65085aa19e6452f62982 Mon Sep 17 00:00:00 2001
+From: Chad Kimes <chkimes@github.com>
+Date: Mon, 21 Mar 2022 18:07:32 -0400
+Subject: [PATCH 5/5] net/drivers/efi/efinet: Configure VLAN from UEFI device
+ used for PXE
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+This patch handles automatic configuration of VLAN when booting from PXE
+on UEFI hardware.
+
+Signed-off-by: Chad Kimes <chkimes@github.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+Upstream-patch: 9322a7740f7ca48d0b23a231af1c7807d9f7b5dd
+
+ grub-core/net/drivers/efi/efinet.c | 38 ++++++++++++++++++++++++++----
+ 1 file changed, 33 insertions(+), 5 deletions(-)
+
+diff --git a/grub-core/net/drivers/efi/efinet.c b/grub-core/net/drivers/efi/efinet.c
+index 5388f952b..099690984 100644
+--- a/grub-core/net/drivers/efi/efinet.c
++++ b/grub-core/net/drivers/efi/efinet.c
+@@ -330,6 +330,10 @@ grub_efi_net_config_real (grub_efi_handle_t hnd, char **device,
+ {
+   struct grub_net_card *card;
+   grub_efi_device_path_t *dp;
++  struct grub_net_network_level_interface *inter;
++  grub_efi_device_path_t *vlan_dp;
++  grub_efi_uint16_t vlan_dp_len;
++  grub_efi_vlan_device_path_t *vlan;
+ 
+   dp = grub_efi_get_device_path (hnd);
+   if (! dp)
+@@ -378,11 +382,35 @@ grub_efi_net_config_real (grub_efi_handle_t hnd, char **device,
+     if (! pxe)
+       continue;
+     pxe_mode = pxe->mode;
+-    grub_net_configure_by_dhcp_ack (card->name, card, 0,
+-				    (struct grub_net_bootp_packet *)
+-				    &pxe_mode->dhcp_ack,
+-				    sizeof (pxe_mode->dhcp_ack),
+-				    1, device, path);
++
++    inter = grub_net_configure_by_dhcp_ack (card->name, card, 0,
++					    (struct grub_net_bootp_packet *)
++					    &pxe_mode->dhcp_ack,
++					    sizeof (pxe_mode->dhcp_ack),
++					    1, device, path);
++
++    if (inter != NULL)
++      {
++	/*
++	 * Search the device path for any VLAN subtype and use it
++	 * to configure the interface.
++	 */
++	vlan_dp = dp;
++
++	while (!GRUB_EFI_END_ENTIRE_DEVICE_PATH (vlan_dp))
++	  {
++	    if (GRUB_EFI_DEVICE_PATH_TYPE (vlan_dp) == GRUB_EFI_MESSAGING_DEVICE_PATH_TYPE &&
++		GRUB_EFI_DEVICE_PATH_SUBTYPE (vlan_dp) == GRUB_EFI_VLAN_DEVICE_PATH_SUBTYPE)
++	      {
++		vlan = (grub_efi_vlan_device_path_t *) vlan_dp;
++		inter->vlantag = vlan->vlan_id;
++		break;
++	      }
++
++	    vlan_dp_len = GRUB_EFI_DEVICE_PATH_LENGTH (vlan_dp);
++	    vlan_dp = (grub_efi_device_path_t *) ((grub_efi_uint8_t *) vlan_dp + vlan_dp_len);
++	  }
++      }
+     return;
+   }
+ }
+-- 
+2.45.2
+

--- a/SPECS/grub.spec
+++ b/SPECS/grub.spec
@@ -48,7 +48,7 @@
 Name:           grub
 Epoch:          1
 Version:        2.06
-Release: %{?xsrel}%{?dist}
+Release: %{?xsrel}.1%{?dist}
 Summary:        Bootloader with support for Linux, Multiboot and more
 
 Group:          System Environment/Base
@@ -59,6 +59,13 @@ Source0: grub-2.06.tar.gz
 Source1: gnulib.tar.gz
 Patch0: wait-before-drain.patch
 Patch1: 0001-lib-relocator-always-enforce-the-requested-alignment.patch
+
+# XCP-ng patches
+Patch1001: 0001-net-ethernet-Fix-VLAN-networking-on-little-endian-sy.patch
+Patch1002: 0002-net-net-Add-vlan-information-to-net_ls_addr-output.patch
+Patch1003: 0003-net-net-Add-net_set_vlan-command.patch
+Patch1004: 0004-kern-efi-efi-Print-VLAN-info-in-EFI-device-path.patch
+Patch1005: 0005-net-drivers-efi-efinet-Configure-VLAN-from-UEFI-devi.patch
 
 BuildRequires:  devtoolset-10-gcc
 BuildRequires:  flex bison binutils python
@@ -401,6 +408,9 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Wed Sep 25 2024 Thierry Escande <thierry.escande@vates.tech> - 2.06-4.0.2.1
+- Backport VLAN networking support for UEFI PXE boot
+
 * Wed May 17 2023 Ross Lagerwall <ross.lagerwall@citrix.com> - 2.06-4.0.2
 - HP-1153: always enforce requested allocation alignment
 


### PR DESCRIPTION
VLAN networking configuration is only supported since Grub v2.12. This commit backports the patches needed to get it to work on Grub v2.06.

All patches apply cleanly without modification.