### PR TITLE
Import grub-2.06-4.0.5

### DIFF
--- a/SOURCES/0001-efi-Increase-default-memory-allocation-to-32-MiB.patch
+++ b/SOURCES/0001-efi-Increase-default-memory-allocation-to-32-MiB.patch
@@ -1,0 +1,33 @@
+From 75e38e86e7d9202f050b093f20500d9ad4c6dad9 Mon Sep 17 00:00:00 2001
+From: Daniel Axtens <dja@axtens.net>
+Date: Tue, 20 Sep 2022 00:30:30 +1000
+Subject: [PATCH 1/1] efi: Increase default memory allocation to 32 MiB
+
+We have multiple reports of things being slower with a 1 MiB initial static
+allocation, and a report (more difficult to nail down) of a boot failure
+as a result of the smaller initial allocation.
+
+Make the initial memory allocation 32 MiB.
+
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ grub-core/kern/efi/mm.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/grub-core/kern/efi/mm.c b/grub-core/kern/efi/mm.c
+index d290c9a76270..3705b8b1b465 100644
+--- a/grub-core/kern/efi/mm.c
++++ b/grub-core/kern/efi/mm.c
+@@ -39,7 +39,7 @@
+ #define MEMORY_MAP_SIZE	0x3000
+ 
+ /* The default heap size for GRUB itself in bytes.  */
+-#define DEFAULT_HEAP_SIZE	0x100000
++#define DEFAULT_HEAP_SIZE	0x2000000
+ 
+ static void *finish_mmap_buf = 0;
+ static grub_efi_uintn_t finish_mmap_size = 0;
+-- 
+2.53.0
+

--- a/SOURCES/0001-kern-efi-mm-Detect-calls-to-grub_efi_drop_alloc-with.patch
+++ b/SOURCES/0001-kern-efi-mm-Detect-calls-to-grub_efi_drop_alloc-with.patch
@@ -1,0 +1,39 @@
+From 55d35d62831af122fadf33c4bc8cd53aada949cb Mon Sep 17 00:00:00 2001
+From: Mate Kukri <mate.kukri@canonical.com>
+Date: Wed, 12 Jun 2024 16:14:21 +0100
+Subject: [PATCH 1/1] kern/efi/mm: Detect calls to grub_efi_drop_alloc() with
+ wrong page counts
+
+Silently keeping entries in the list if the address matches, but the
+page count doesn't is a bad idea, and can lead to double frees.
+
+grub_efi_free_pages() have already freed parts of this block by this
+point, and thus keeping the whole block in the list and freeing it again
+at exit can lead to double frees.
+
+Signed-off-by: Mate Kukri <mate.kukri@canonical.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ grub-core/kern/efi/mm.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/grub-core/kern/efi/mm.c b/grub-core/kern/efi/mm.c
+index bc18b149d282..df7bf2869889 100644
+--- a/grub-core/kern/efi/mm.c
++++ b/grub-core/kern/efi/mm.c
+@@ -95,8 +95,10 @@ grub_efi_drop_alloc (grub_efi_physical_address_t address,
+ 
+   for (eap = NULL, ea = efi_allocated_memory; ea; eap = ea, ea = ea->next)
+     {
+-      if (ea->address != address || ea->pages != pages)
+-         continue;
++      if (ea->address != address)
++	continue;
++      if (ea->pages != pages)
++	grub_fatal ("grub_efi_drop_alloc() called with wrong page count");
+ 
+       /* Remove the current entry from the list. */
+       if (eap)
+-- 
+2.53.0
+

--- a/SOURCES/0001-kern-efi-mm-Fix-use-after-free-in-finish-boot-servic.patch
+++ b/SOURCES/0001-kern-efi-mm-Fix-use-after-free-in-finish-boot-servic.patch
@@ -1,0 +1,44 @@
+From 6f05a277961dc801ba6de4f0f3bc22184ae80b0f Mon Sep 17 00:00:00 2001
+From: Alec Brown <alec.r.brown@oracle.com>
+Date: Mon, 22 May 2023 16:52:49 -0400
+Subject: [PATCH 1/1] kern/efi/mm: Fix use-after-free in finish boot services
+
+In grub-core/kern/efi/mm.c, grub_efi_finish_boot_services() has an instance
+where the memory for the variable finish_mmap_buf is freed, but on the next
+iteration of a while loop, grub_efi_get_memory_map() uses finish_mmap_buf. To
+prevent this, we can set finish_mmap_buf to NULL after the free.
+
+Signed-off-by: Alec Brown <alec.r.brown@oracle.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ grub-core/kern/efi/mm.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/grub-core/kern/efi/mm.c b/grub-core/kern/efi/mm.c
+index 2be0e697359d..6a6fba891846 100644
+--- a/grub-core/kern/efi/mm.c
++++ b/grub-core/kern/efi/mm.c
+@@ -263,6 +263,7 @@ grub_efi_finish_boot_services (grub_efi_uintn_t *outbuf_size, void *outbuf,
+ 				   &finish_desc_size, &finish_desc_version) <= 0)
+ 	{
+ 	  grub_free (finish_mmap_buf);
++	  finish_mmap_buf = NULL;
+ 	  return grub_error (GRUB_ERR_IO, "couldn't retrieve memory map");
+ 	}
+ 
+@@ -274,10 +275,12 @@ grub_efi_finish_boot_services (grub_efi_uintn_t *outbuf_size, void *outbuf,
+       if (status != GRUB_EFI_INVALID_PARAMETER)
+ 	{
+ 	  grub_free (finish_mmap_buf);
++	  finish_mmap_buf = NULL;
+ 	  return grub_error (GRUB_ERR_IO, "couldn't terminate EFI services");
+ 	}
+ 
+       grub_free (finish_mmap_buf);
++      finish_mmap_buf = NULL;
+       grub_printf ("Trying to terminate EFI services again\n");
+     }
+   grub_efi_is_finished = 1;
+-- 
+2.53.0
+

--- a/SOURCES/0001-lib-relocator-Always-enforce-the-requested-alignment.patch
+++ b/SOURCES/0001-lib-relocator-Always-enforce-the-requested-alignment.patch
@@ -1,7 +1,7 @@
-From 45d7b7f508a6ab5bd1837920574f3d3d526271e0 Mon Sep 17 00:00:00 2001
-From: Roger Pau Monne <roger.pau@citrix.com>
-Date: Thu, 27 Apr 2023 16:52:44 +0200
-Subject: [PATCH v2] lib/relocator: always enforce the requested alignment in
+From 4127ea3a9ae0831018d48d91003389e57e47708f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Roger=20Pau=20Monn=C3=A9?= <roger.pau@citrix.com>
+Date: Fri, 12 May 2023 09:33:55 +0200
+Subject: [PATCH 1/1] lib/relocator: Always enforce the requested alignment in
  malloc_in_range()
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -11,22 +11,21 @@ On failure to allocate from grub_relocator_firmware_alloc_region() in
 malloc_in_range() the function would stop enforcing the alignment, and
 the following was returned:
 
-lib/relocator.c:431: trying to allocate in 0x200000-0xffbf9fff aligned 0x200000 size 0x406000
-lib/relocator.c:1197: allocated: 0x74de2000+0x406000
-lib/relocator.c:1407: allocated 0x74de2000/0x74de2000
+  lib/relocator.c:431: trying to allocate in 0x200000-0xffbf9fff aligned 0x200000 size 0x406000
+  lib/relocator.c:1197: allocated: 0x74de2000+0x406000
+  lib/relocator.c:1407: allocated 0x74de2000/0x74de2000
 
 Fix this by making sure that target always contains a suitably aligned
-address.  After the change the return from the function is:
+address. After the change the return from the function is:
 
-lib/relocator.c:431: trying to allocate in 0x200000-0xffb87fff aligned 0x200000 size 0x478000
-lib/relocator.c:1204: allocated: 0x74c00000+0x478000
-lib/relocator.c:1414: allocated 0x74c00000/0x74c00000
+  lib/relocator.c:431: trying to allocate in 0x200000-0xffb87fff aligned 0x200000 size 0x478000
+  lib/relocator.c:1204: allocated: 0x74c00000+0x478000
+  lib/relocator.c:1414: allocated 0x74c00000/0x74c00000
 
-Fixes: 3a5768645c05 ('First version of allocation from firmware')
+Fixes: 3a5768645c05 (First version of allocation from firmware)
+
 Signed-off-by: Roger Pau Monné <roger.pau@citrix.com>
----
-Changes since v1:
- - Fix one instance to use ALIGN_DOWN().
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
 ---
  grub-core/lib/relocator.c | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
@@ -54,5 +53,5 @@ index bfcc70dac3cc..725bca7c3c10 100644
  		goto found;
  	    }
 -- 
-2.40.0
+2.53.0
 

--- a/SOURCES/0001-mm-Assert-that-we-preserve-header-vs-region-alignmen.patch
+++ b/SOURCES/0001-mm-Assert-that-we-preserve-header-vs-region-alignmen.patch
@@ -1,0 +1,58 @@
+From 1df8fe66c57087eb33bd6dc69f786ed124615aa7 Mon Sep 17 00:00:00 2001
+From: Daniel Axtens <dja@axtens.net>
+Date: Thu, 21 Apr 2022 15:24:14 +1000
+Subject: [PATCH 1/1] mm: Assert that we preserve header vs region alignment
+
+grub_mm_region_init() does:
+
+  h = (grub_mm_header_t) (r + 1);
+
+where h is a grub_mm_header_t and r is a grub_mm_region_t.
+
+Cells are supposed to be GRUB_MM_ALIGN aligned, but while grub_mm_dump
+ensures this vs the region header, grub_mm_region_init() does not.
+
+It's better to be explicit than implicit here: rather than changing
+grub_mm_region_init() to ALIGN_UP(), require that the struct is
+explicitly a multiple of the header size.
+
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+Tested-by: Patrick Steinhardt <ps@pks.im>
+---
+ include/grub/mm_private.h | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/include/grub/mm_private.h b/include/grub/mm_private.h
+index 203533cc3d42..a688b92a835f 100644
+--- a/include/grub/mm_private.h
++++ b/include/grub/mm_private.h
+@@ -20,6 +20,7 @@
+ #define GRUB_MM_PRIVATE_H	1
+ 
+ #include <grub/mm.h>
++#include <grub/misc.h>
+ 
+ /* For context, see kern/mm.c */
+ 
+@@ -89,4 +90,17 @@ typedef struct grub_mm_region
+ extern grub_mm_region_t EXPORT_VAR (grub_mm_base);
+ #endif
+ 
++static inline void
++grub_mm_size_sanity_check (void) {
++  /* Ensure we preserve alignment when doing h = (grub_mm_header_t) (r + 1). */
++  COMPILE_TIME_ASSERT ((sizeof (struct grub_mm_region) %
++		        sizeof (struct grub_mm_header)) == 0);
++
++  /*
++   * GRUB_MM_ALIGN is supposed to represent cell size, and a mm_header is
++   * supposed to be 1 cell.
++   */
++  COMPILE_TIME_ASSERT (sizeof (struct grub_mm_header) == GRUB_MM_ALIGN);
++}
++
+ #endif
+-- 
+2.53.0
+

--- a/SOURCES/0001-mm-Document-GRUB-internal-memory-management-structur.patch
+++ b/SOURCES/0001-mm-Document-GRUB-internal-memory-management-structur.patch
@@ -1,0 +1,80 @@
+From a6c5c52ccffd2674d43db25fb4baa9c528526aa0 Mon Sep 17 00:00:00 2001
+From: Daniel Axtens <dja@axtens.net>
+Date: Thu, 25 Nov 2021 02:22:45 +1100
+Subject: [PATCH 1/1] mm: Document GRUB internal memory management structures
+
+I spent more than a trivial quantity of time figuring out pre_size and
+whether a memory region's size contains the header cell or not.
+
+Document the meanings of all the properties. Hopefully now no-one else
+has to figure it out!
+
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ include/grub/mm_private.h | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/include/grub/mm_private.h b/include/grub/mm_private.h
+index c2c4cb1511c6..203533cc3d42 100644
+--- a/include/grub/mm_private.h
++++ b/include/grub/mm_private.h
+@@ -21,15 +21,27 @@
+ 
+ #include <grub/mm.h>
+ 
++/* For context, see kern/mm.c */
++
+ /* Magic words.  */
+ #define GRUB_MM_FREE_MAGIC	0x2d3c2808
+ #define GRUB_MM_ALLOC_MAGIC	0x6db08fa4
+ 
++/* A header describing a block of memory - either allocated or free */
+ typedef struct grub_mm_header
+ {
++  /*
++   * The 'next' free block in this region's circular free list.
++   * Only meaningful if the block is free.
++   */
+   struct grub_mm_header *next;
++  /* The block size, not in bytes but the number of cells of
++   * GRUB_MM_ALIGN bytes. Includes the header cell.
++   */
+   grub_size_t size;
++  /* either free or alloc magic, depending on the block type. */
+   grub_size_t magic;
++  /* pad to cell size: see the top of kern/mm.c. */
+ #if GRUB_CPU_SIZEOF_VOID_P == 4
+   char padding[4];
+ #elif GRUB_CPU_SIZEOF_VOID_P == 8
+@@ -48,11 +60,27 @@ typedef struct grub_mm_header
+ 
+ #define GRUB_MM_ALIGN	(1 << GRUB_MM_ALIGN_LOG2)
+ 
++/* A region from which we can make allocations. */
+ typedef struct grub_mm_region
+ {
++  /* The first free block in this region. */
+   struct grub_mm_header *first;
++
++  /*
++   * The next region in the linked list of regions. Regions are initially
++   * sorted in order of increasing size, but can grow, in which case the
++   * ordering may not be preserved.
++   */
+   struct grub_mm_region *next;
++
++  /*
++   * A grub_mm_region will always be aligned to cell size. The pre-size is
++   * the number of bytes we were given but had to skip in order to get that
++   * alignment.
++   */
+   grub_size_t pre_size;
++
++  /* How many bytes are in this region? (free and allocated) */
+   grub_size_t size;
+ }
+ *grub_mm_region_t;
+-- 
+2.53.0
+

--- a/SOURCES/0002-kern-efi-mm-Change-grub_efi_mm_add_regions-to-keep-t.patch
+++ b/SOURCES/0002-kern-efi-mm-Change-grub_efi_mm_add_regions-to-keep-t.patch
@@ -1,0 +1,74 @@
+From dc0a3a27d67a6b1639d155cc69e8537077af1047 Mon Sep 17 00:00:00 2001
+From: Mate Kukri <mate.kukri@canonical.com>
+Date: Wed, 12 Jun 2024 16:10:49 +0100
+Subject: [PATCH 2/2] kern/efi/mm: Change grub_efi_mm_add_regions() to keep
+ track of map allocation size
+
+If the map was too big for the initial allocation, it was freed and replaced
+with a bigger one, but the free call still used the hard-coded size.
+
+Seems like this wasn't hit for a long time, because most firmware maps
+fit into 12K.
+
+This bug was triggered on Project Mu firmware with a big memory map, and
+results in the heap getting trashed and the firmware ASSERTING on
+corrupted heap guard values when GRUB exits.
+
+Signed-off-by: Mate Kukri <mate.kukri@canonical.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ grub-core/kern/efi/mm.c | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/grub-core/kern/efi/mm.c b/grub-core/kern/efi/mm.c
+index 6a6fba891846..739229e7b53b 100644
+--- a/grub-core/kern/efi/mm.c
++++ b/grub-core/kern/efi/mm.c
+@@ -574,13 +574,15 @@ grub_efi_mm_add_regions (grub_size_t required_bytes, unsigned int flags)
+   grub_efi_memory_descriptor_t *memory_map_end;
+   grub_efi_memory_descriptor_t *filtered_memory_map;
+   grub_efi_memory_descriptor_t *filtered_memory_map_end;
++  grub_efi_uintn_t alloc_size;
+   grub_efi_uintn_t map_size;
+   grub_efi_uintn_t desc_size;
+   grub_err_t err;
+   int mm_status;
+ 
+   /* Prepare a memory region to store two memory maps.  */
+-  memory_map = grub_efi_allocate_any_pages (2 * BYTES_TO_PAGES (MEMORY_MAP_SIZE));
++  alloc_size = 2 * BYTES_TO_PAGES (MEMORY_MAP_SIZE);
++  memory_map = grub_efi_allocate_any_pages (alloc_size);
+   if (! memory_map)
+     return grub_error (GRUB_ERR_OUT_OF_MEMORY, "cannot allocate memory for memory map");
+ 
+@@ -591,14 +593,13 @@ grub_efi_mm_add_regions (grub_size_t required_bytes, unsigned int flags)
+ 
+   if (mm_status == 0)
+     {
+-      grub_efi_free_pages
+-	((grub_efi_physical_address_t) ((grub_addr_t) memory_map),
+-	 2 * BYTES_TO_PAGES (MEMORY_MAP_SIZE));
++      grub_efi_free_pages ((grub_efi_physical_address_t)(grub_addr_t) memory_map, alloc_size);
+ 
+       /* Freeing/allocating operations may increase memory map size.  */
+       map_size += desc_size * 32;
+ 
+-      memory_map = grub_efi_allocate_any_pages (2 * BYTES_TO_PAGES (map_size));
++      alloc_size = 2 * BYTES_TO_PAGES (map_size);
++      memory_map = grub_efi_allocate_any_pages (alloc_size);
+       if (! memory_map)
+ 	return grub_error (GRUB_ERR_OUT_OF_MEMORY, "cannot allocate memory for new memory map");
+ 
+@@ -642,8 +643,7 @@ grub_efi_mm_add_regions (grub_size_t required_bytes, unsigned int flags)
+ #endif
+ 
+   /* Release the memory maps.  */
+-  grub_efi_free_pages ((grub_addr_t) memory_map,
+-		       2 * BYTES_TO_PAGES (MEMORY_MAP_SIZE));
++  grub_efi_free_pages ((grub_efi_physical_address_t)(grub_addr_t) memory_map, alloc_size);
+ 
+   return GRUB_ERR_NONE;
+ }
+-- 
+2.53.0
+

--- a/SOURCES/0002-mm-Clarify-grub_real_malloc.patch
+++ b/SOURCES/0002-mm-Clarify-grub_real_malloc.patch
@@ -1,0 +1,185 @@
+From 246ad6a44c281bb13486ddea0a26bb661db73106 Mon Sep 17 00:00:00 2001
+From: Daniel Axtens <dja@axtens.net>
+Date: Thu, 25 Nov 2021 02:22:46 +1100
+Subject: [PATCH 2/2] mm: Clarify grub_real_malloc()
+
+When iterating through the singly linked list of free blocks,
+grub_real_malloc() uses p and q for the current and previous blocks
+respectively. This isn't super clear, so swap to using prev and cur.
+
+This makes another quirk more obvious. The comment at the top of
+grub_real_malloc() might lead you to believe that the function will
+allocate from *first if there is space in that block.
+
+It actually doesn't do that, and it can't do that with the current
+data structures. If we used up all of *first, we would need to change
+the ->next of the previous block to point to *first->next, but we
+can't do that because it's a singly linked list and we don't have
+access to *first's previous block.
+
+What grub_real_malloc() actually does is set *first to the initial
+previous block, and *first->next is the block we try to allocate
+from. That allows us to keep all the data structures consistent.
+
+Document that.
+
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ grub-core/kern/mm.c | 76 ++++++++++++++++++++++++---------------------
+ 1 file changed, 41 insertions(+), 35 deletions(-)
+
+diff --git a/grub-core/kern/mm.c b/grub-core/kern/mm.c
+index c070afc621f8..6efabe92df0e 100644
+--- a/grub-core/kern/mm.c
++++ b/grub-core/kern/mm.c
+@@ -178,13 +178,20 @@ grub_mm_init_region (void *addr, grub_size_t size)
+ }
+ 
+ /* Allocate the number of units N with the alignment ALIGN from the ring
+-   buffer starting from *FIRST.  ALIGN must be a power of two. Both N and
+-   ALIGN are in units of GRUB_MM_ALIGN.  Return a non-NULL if successful,
+-   otherwise return NULL.  */
++ * buffer given in *FIRST.  ALIGN must be a power of two. Both N and
++ * ALIGN are in units of GRUB_MM_ALIGN.  Return a non-NULL if successful,
++ * otherwise return NULL.
++ *
++ * Note: because in certain circumstances we need to adjust the ->next
++ * pointer of the previous block, we iterate over the singly linked
++ * list with the pair (prev, cur). *FIRST is our initial previous, and
++ * *FIRST->next is our initial current pointer. So we will actually
++ * allocate from *FIRST->next first and *FIRST itself last.
++ */
+ static void *
+ grub_real_malloc (grub_mm_header_t *first, grub_size_t n, grub_size_t align)
+ {
+-  grub_mm_header_t p, q;
++  grub_mm_header_t cur, prev;
+ 
+   /* When everything is allocated side effect is that *first will have alloc
+      magic marked, meaning that there is no room in this region.  */
+@@ -192,24 +199,24 @@ grub_real_malloc (grub_mm_header_t *first, grub_size_t n, grub_size_t align)
+     return 0;
+ 
+   /* Try to search free slot for allocation in this memory region.  */
+-  for (q = *first, p = q->next; ; q = p, p = p->next)
++  for (prev = *first, cur = prev->next; ; prev = cur, cur = cur->next)
+     {
+       grub_off_t extra;
+ 
+-      extra = ((grub_addr_t) (p + 1) >> GRUB_MM_ALIGN_LOG2) & (align - 1);
++      extra = ((grub_addr_t) (cur + 1) >> GRUB_MM_ALIGN_LOG2) & (align - 1);
+       if (extra)
+ 	extra = align - extra;
+ 
+-      if (! p)
++      if (! cur)
+ 	grub_fatal ("null in the ring");
+ 
+-      if (p->magic != GRUB_MM_FREE_MAGIC)
+-	grub_fatal ("free magic is broken at %p: 0x%x", p, p->magic);
++      if (cur->magic != GRUB_MM_FREE_MAGIC)
++	grub_fatal ("free magic is broken at %p: 0x%x", cur, cur->magic);
+ 
+-      if (p->size >= n + extra)
++      if (cur->size >= n + extra)
+ 	{
+-	  extra += (p->size - extra - n) & (~(align - 1));
+-	  if (extra == 0 && p->size == n)
++	  extra += (cur->size - extra - n) & (~(align - 1));
++	  if (extra == 0 && cur->size == n)
+ 	    {
+ 	      /* There is no special alignment requirement and memory block
+ 	         is complete match.
+@@ -222,9 +229,9 @@ grub_real_malloc (grub_mm_header_t *first, grub_size_t n, grub_size_t align)
+ 	         | alloc, size=n |          |
+ 	         +---------------+          v
+ 	       */
+-	      q->next = p->next;
++	      prev->next = cur->next;
+ 	    }
+-	  else if (align == 1 || p->size == n + extra)
++	  else if (align == 1 || cur->size == n + extra)
+ 	    {
+ 	      /* There might be alignment requirement, when taking it into
+ 	         account memory block fits in.
+@@ -241,23 +248,22 @@ grub_real_malloc (grub_mm_header_t *first, grub_size_t n, grub_size_t align)
+ 	         | alloc, size=n |        |
+ 	         +---------------+        v
+ 	       */
+-
+-	      p->size -= n;
+-	      p += p->size;
++	      cur->size -= n;
++	      cur += cur->size;
+ 	    }
+ 	  else if (extra == 0)
+ 	    {
+ 	      grub_mm_header_t r;
+ 	      
+-	      r = p + extra + n;
++	      r = cur + extra + n;
+ 	      r->magic = GRUB_MM_FREE_MAGIC;
+-	      r->size = p->size - extra - n;
+-	      r->next = p->next;
+-	      q->next = r;
++	      r->size = cur->size - extra - n;
++	      r->next = cur->next;
++	      prev->next = r;
+ 
+-	      if (q == p)
++	      if (prev == cur)
+ 		{
+-		  q = r;
++		  prev = r;
+ 		  r->next = r;
+ 		}
+ 	    }
+@@ -284,32 +290,32 @@ grub_real_malloc (grub_mm_header_t *first, grub_size_t n, grub_size_t align)
+ 	       */
+ 	      grub_mm_header_t r;
+ 
+-	      r = p + extra + n;
++	      r = cur + extra + n;
+ 	      r->magic = GRUB_MM_FREE_MAGIC;
+-	      r->size = p->size - extra - n;
+-	      r->next = p;
++	      r->size = cur->size - extra - n;
++	      r->next = cur;
+ 
+-	      p->size = extra;
+-	      q->next = r;
+-	      p += extra;
++	      cur->size = extra;
++	      prev->next = r;
++	      cur += extra;
+ 	    }
+ 
+-	  p->magic = GRUB_MM_ALLOC_MAGIC;
+-	  p->size = n;
++	  cur->magic = GRUB_MM_ALLOC_MAGIC;
++	  cur->size = n;
+ 
+ 	  /* Mark find as a start marker for next allocation to fasten it.
+ 	     This will have side effect of fragmenting memory as small
+ 	     pieces before this will be un-used.  */
+ 	  /* So do it only for chunks under 64K.  */
+ 	  if (n < (0x8000 >> GRUB_MM_ALIGN_LOG2)
+-	      || *first == p)
+-	    *first = q;
++	      || *first == cur)
++	    *first = prev;
+ 
+-	  return p + 1;
++	  return cur + 1;
+ 	}
+ 
+       /* Search was completed without result.  */
+-      if (p == *first)
++      if (cur == *first)
+ 	break;
+     }
+ 
+-- 
+2.53.0
+

--- a/SOURCES/0002-mm-When-adding-a-region-merge-with-region-after-as-w.patch
+++ b/SOURCES/0002-mm-When-adding-a-region-merge-with-region-after-as-w.patch
@@ -1,0 +1,206 @@
+From 052e6068be622ff53f1238b449c300dbd0a8abcd Mon Sep 17 00:00:00 2001
+From: Daniel Axtens <dja@axtens.net>
+Date: Thu, 21 Apr 2022 15:24:15 +1000
+Subject: [PATCH 2/2] mm: When adding a region, merge with region after as well
+ as before
+
+On x86_64-efi (at least) regions seem to be added from top down. The mm
+code will merge a new region with an existing region that comes
+immediately before the new region. This allows larger allocations to be
+satisfied that would otherwise be the case.
+
+On powerpc-ieee1275, however, regions are added from bottom up. So if
+we add 3x 32MB regions, we can still only satisfy a 32MB allocation,
+rather than the 96MB allocation we might otherwise be able to satisfy.
+
+  * Define 'post_size' as being bytes lost to the end of an allocation
+    due to being given weird sizes from firmware that are not multiples
+    of GRUB_MM_ALIGN.
+
+  * Allow merging of regions immediately _after_ existing regions, not
+    just before. As with the other approach, we create an allocated
+    block to represent the new space and the pass it to grub_free() to
+    get the metadata right.
+
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Tested-by: Stefan Berger <stefanb@linux.ibm.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+Tested-by: Patrick Steinhardt <ps@pks.im>
+---
+ grub-core/kern/mm.c       | 130 ++++++++++++++++++++++++--------------
+ include/grub/mm_private.h |   9 +++
+ 2 files changed, 92 insertions(+), 47 deletions(-)
+
+diff --git a/grub-core/kern/mm.c b/grub-core/kern/mm.c
+index 079c28da7cdf..b406906a9b41 100644
+--- a/grub-core/kern/mm.c
++++ b/grub-core/kern/mm.c
+@@ -130,53 +130,88 @@ grub_mm_init_region (void *addr, grub_size_t size)
+ 
+   /* Attempt to merge this region with every existing region */
+   for (p = &grub_mm_base, q = *p; q; p = &(q->next), q = *p)
+-    /*
+-     * Is the new region immediately below an existing region? That
+-     * is, is the address of the memory we're adding now (addr) + size
+-     * of the memory we're adding (size) + the bytes we couldn't use
+-     * at the start of the region we're considering (q->pre_size)
+-     * equal to the address of q? In other words, does the memory
+-     * looks like this?
+-     *
+-     * addr                          q
+-     *   |----size-----|-q->pre_size-|<q region>|
+-     */
+-    if ((grub_uint8_t *) addr + size + q->pre_size == (grub_uint8_t *) q)
+-      {
+-	/*
+-	 * Yes, we can merge the memory starting at addr into the
+-	 * existing region from below. Align up addr to GRUB_MM_ALIGN
+-	 * so that our new region has proper alignment.
+-	 */
+-	r = (grub_mm_region_t) ALIGN_UP ((grub_addr_t) addr, GRUB_MM_ALIGN);
+-	/* Copy the region data across */
+-	*r = *q;
+-	/* Consider all the new size as pre-size */
+-	r->pre_size += size;
+-
+-	/*
+-	 * If we have enough pre-size to create a block, create a
+-	 * block with it. Mark it as allocated and pass it to
+-	 * grub_free (), which will sort out getting it into the free
+-	 * list.
+-	 */
+-	if (r->pre_size >> GRUB_MM_ALIGN_LOG2)
+-	  {
+-	    h = (grub_mm_header_t) (r + 1);
+-	    /* block size is pre-size converted to cells */
+-	    h->size = (r->pre_size >> GRUB_MM_ALIGN_LOG2);
+-	    h->magic = GRUB_MM_ALLOC_MAGIC;
+-	    /* region size grows by block size converted back to bytes */
+-	    r->size += h->size << GRUB_MM_ALIGN_LOG2;
+-	    /* adjust pre_size to be accurate */
+-	    r->pre_size &= (GRUB_MM_ALIGN - 1);
+-	    *p = r;
+-	    grub_free (h + 1);
+-	  }
+-	/* Replace the old region with the new region */
+-	*p = r;
+-	return;
+-      }
++    {
++      /*
++       * Is the new region immediately below an existing region? That
++       * is, is the address of the memory we're adding now (addr) + size
++       * of the memory we're adding (size) + the bytes we couldn't use
++       * at the start of the region we're considering (q->pre_size)
++       * equal to the address of q? In other words, does the memory
++       * looks like this?
++       *
++       * addr                          q
++       *   |----size-----|-q->pre_size-|<q region>|
++       */
++      if ((grub_uint8_t *) addr + size + q->pre_size == (grub_uint8_t *) q)
++        {
++          /*
++           * Yes, we can merge the memory starting at addr into the
++           * existing region from below. Align up addr to GRUB_MM_ALIGN
++           * so that our new region has proper alignment.
++           */
++          r = (grub_mm_region_t) ALIGN_UP ((grub_addr_t) addr, GRUB_MM_ALIGN);
++          /* Copy the region data across */
++          *r = *q;
++          /* Consider all the new size as pre-size */
++          r->pre_size += size;
++
++          /*
++           * If we have enough pre-size to create a block, create a
++           * block with it. Mark it as allocated and pass it to
++           * grub_free (), which will sort out getting it into the free
++           * list.
++           */
++          if (r->pre_size >> GRUB_MM_ALIGN_LOG2)
++            {
++              h = (grub_mm_header_t) (r + 1);
++              /* block size is pre-size converted to cells */
++              h->size = (r->pre_size >> GRUB_MM_ALIGN_LOG2);
++              h->magic = GRUB_MM_ALLOC_MAGIC;
++              /* region size grows by block size converted back to bytes */
++              r->size += h->size << GRUB_MM_ALIGN_LOG2;
++              /* adjust pre_size to be accurate */
++              r->pre_size &= (GRUB_MM_ALIGN - 1);
++              *p = r;
++              grub_free (h + 1);
++            }
++          /* Replace the old region with the new region */
++          *p = r;
++          return;
++        }
++
++      /*
++       * Is the new region immediately above an existing region? That
++       * is:
++       *   q                       addr
++       *   |<q region>|-q->post_size-|----size-----|
++       */
++      if ((grub_uint8_t *) q + sizeof (*q) + q->size + q->post_size ==
++	  (grub_uint8_t *) addr)
++	{
++	  /*
++	   * Yes! Follow a similar pattern to above, but simpler.
++	   * Our header starts at address - post_size, which should align us
++	   * to a cell boundary.
++	   *
++	   * Cast to (void *) first to avoid the following build error:
++	   *   kern/mm.c: In function ‘grub_mm_init_region’:
++	   *   kern/mm.c:211:15: error: cast increases required alignment of target type [-Werror=cast-align]
++	   *     211 |           h = (grub_mm_header_t) ((grub_uint8_t *) addr - q->post_size);
++	   *         |               ^
++	   * It is safe to do that because proper alignment is enforced in grub_mm_size_sanity_check().
++	   */
++	  h = (grub_mm_header_t)(void *) ((grub_uint8_t *) addr - q->post_size);
++	  /* our size is the allocated size plus post_size, in cells */
++	  h->size = (size + q->post_size) >> GRUB_MM_ALIGN_LOG2;
++	  h->magic = GRUB_MM_ALLOC_MAGIC;
++	  /* region size grows by block size converted back to bytes */
++	  q->size += h->size << GRUB_MM_ALIGN_LOG2;
++	  /* adjust new post_size to be accurate */
++	  q->post_size = (q->post_size + size) & (GRUB_MM_ALIGN - 1);
++	  grub_free (h + 1);
++	  return;
++	}
++    }
+ 
+   /* Allocate a region from the head.  */
+   r = (grub_mm_region_t) ALIGN_UP ((grub_addr_t) addr, GRUB_MM_ALIGN);
+@@ -195,6 +230,7 @@ grub_mm_init_region (void *addr, grub_size_t size)
+   r->first = h;
+   r->pre_size = (grub_addr_t) r - (grub_addr_t) addr;
+   r->size = (h->size << GRUB_MM_ALIGN_LOG2);
++  r->post_size = size - r->size;
+ 
+   /* Find where to insert this region. Put a smaller one before bigger ones,
+      to prevent fragmentation.  */
+diff --git a/include/grub/mm_private.h b/include/grub/mm_private.h
+index a688b92a835f..96c2d816be6b 100644
+--- a/include/grub/mm_private.h
++++ b/include/grub/mm_private.h
+@@ -81,8 +81,17 @@ typedef struct grub_mm_region
+    */
+   grub_size_t pre_size;
+ 
++  /*
++   * Likewise, the post-size is the number of bytes we wasted at the end
++   * of the allocation because it wasn't a multiple of GRUB_MM_ALIGN
++   */
++  grub_size_t post_size;
++
+   /* How many bytes are in this region? (free and allocated) */
+   grub_size_t size;
++
++  /* pad to a multiple of cell size */
++  char padding[3 * GRUB_CPU_SIZEOF_VOID_P];
+ }
+ *grub_mm_region_t;
+ 
+-- 
+2.53.0
+

--- a/SOURCES/0003-kern-efi-mm-Change-grub_efi_allocate_pages_real-to-c.patch
+++ b/SOURCES/0003-kern-efi-mm-Change-grub_efi_allocate_pages_real-to-c.patch
@@ -1,0 +1,34 @@
+From 61f1d0a612a01c2f48f718ff04590ff481e028f8 Mon Sep 17 00:00:00 2001
+From: Mate Kukri <mate.kukri@canonical.com>
+Date: Wed, 12 Jun 2024 16:10:50 +0100
+Subject: [PATCH 3/3] kern/efi/mm: Change grub_efi_allocate_pages_real() to
+ call semantically correct free function
+
+If the firmware happens to return 0 as an address of allocated pages,
+grub_efi_allocate_pages_real() tries to allocate a new set of pages,
+and then free the ones at address 0.
+
+However at that point grub_efi_store_alloc() wasn't yet called, so
+freeing the pages at 0 using grub_efi_free_pages() which calls
+grub_efi_drop_alloc() isn't necessary, so let's call b->free_pages()
+instead.
+
+The call to grub_efi_drop_alloc() doesn't seem particularly harmful,
+because it seems to do nothing if the allocation it is asked to drop
+isn't on the list, but the call to it is obviously unnecessary here.
+
+Signed-off-by: Mate Kukri <mate.kukri@canonical.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+diff --git a/grub-core/kern/efi/mm.c b/grub-core/kern/efi/mm.c
+index e6c30af04a89..76c123d90ecd 100644
+--- a/grub-core/kern/efi/mm.c
++++ b/grub-core/kern/efi/mm.c
+@@ -152,7 +152,7 @@ grub_efi_allocate_pages_real (grub_efi_physical_address_t address,
+ 	 so reallocate another one.  */
+       address = GRUB_EFI_MAX_USABLE_ADDRESS;
+       status = efi_call_4 (b->allocate_pages, alloctype, memtype, pages, &address);
+-      grub_efi_free_pages (0, pages);
++      efi_call_2 (b->free_pages, 0, pages);
+       if (status != GRUB_EFI_SUCCESS)
+ 	{
+ 	  grub_error (GRUB_ERR_OUT_OF_MEMORY, N_("out of memory"));

--- a/SOURCES/0003-mm-Debug-support-for-region-operations.patch
+++ b/SOURCES/0003-mm-Debug-support-for-region-operations.patch
@@ -1,0 +1,73 @@
+From 8afa5ef45b797ba5d8147ceee85ac2c59dcc7f09 Mon Sep 17 00:00:00 2001
+From: Daniel Axtens <dja@axtens.net>
+Date: Thu, 21 Apr 2022 15:24:16 +1000
+Subject: [PATCH 3/3] mm: Debug support for region operations
+
+This is handy for debugging. Enable with "set debug=regions".
+
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+Tested-by: Patrick Steinhardt <ps@pks.im>
+---
+ grub-core/kern/mm.c | 19 ++++++++++++++++---
+ 1 file changed, 16 insertions(+), 3 deletions(-)
+
+diff --git a/grub-core/kern/mm.c b/grub-core/kern/mm.c
+index b406906a9b41..43d4e609f6b0 100644
+--- a/grub-core/kern/mm.c
++++ b/grub-core/kern/mm.c
+@@ -115,9 +115,8 @@ grub_mm_init_region (void *addr, grub_size_t size)
+   grub_mm_header_t h;
+   grub_mm_region_t r, *p, q;
+ 
+-#if 0
+-  grub_printf ("Using memory for heap: start=%p, end=%p\n", addr, addr + (unsigned int) size);
+-#endif
++  grub_dprintf ("regions", "Using memory for heap: start=%p, end=%p\n",
++                addr, (char *) addr + (unsigned int) size);
+ 
+   /* Exclude last 4K to avoid overflows. */
+   /* If addr + 0x1000 overflows then whole region is in excluded zone.  */
+@@ -142,8 +141,14 @@ grub_mm_init_region (void *addr, grub_size_t size)
+        * addr                          q
+        *   |----size-----|-q->pre_size-|<q region>|
+        */
++      grub_dprintf ("regions", "Can we extend into region above?"
++		    " %p + %" PRIxGRUB_SIZE " + %" PRIxGRUB_SIZE " ?=? %p\n",
++		    (grub_uint8_t *) addr, size, q->pre_size, (grub_uint8_t *) q);
+       if ((grub_uint8_t *) addr + size + q->pre_size == (grub_uint8_t *) q)
+         {
++	  grub_dprintf ("regions", "Yes: extending a region: (%p -> %p) -> (%p -> %p)\n",
++			q, (grub_uint8_t *) q + sizeof (*q) + q->size,
++			addr, (grub_uint8_t *) q + sizeof (*q) + q->size);
+           /*
+            * Yes, we can merge the memory starting at addr into the
+            * existing region from below. Align up addr to GRUB_MM_ALIGN
+@@ -185,9 +190,15 @@ grub_mm_init_region (void *addr, grub_size_t size)
+        *   q                       addr
+        *   |<q region>|-q->post_size-|----size-----|
+        */
++      grub_dprintf ("regions", "Can we extend into region below?"
++                    " %p + %" PRIxGRUB_SIZE " + %" PRIxGRUB_SIZE " + %" PRIxGRUB_SIZE " ?=? %p\n",
++                    (grub_uint8_t *) q, sizeof(*q), q->size, q->post_size, (grub_uint8_t *) addr);
+       if ((grub_uint8_t *) q + sizeof (*q) + q->size + q->post_size ==
+ 	  (grub_uint8_t *) addr)
+ 	{
++	  grub_dprintf ("regions", "Yes: extending a region: (%p -> %p) -> (%p -> %p)\n",
++			q, (grub_uint8_t *) q + sizeof (*q) + q->size,
++			q, (grub_uint8_t *) addr + size);
+ 	  /*
+ 	   * Yes! Follow a similar pattern to above, but simpler.
+ 	   * Our header starts at address - post_size, which should align us
+@@ -213,6 +224,8 @@ grub_mm_init_region (void *addr, grub_size_t size)
+ 	}
+     }
+ 
++  grub_dprintf ("regions", "No: considering a new region at %p of size %" PRIxGRUB_SIZE "\n",
++		addr, size);
+   /* Allocate a region from the head.  */
+   r = (grub_mm_region_t) ALIGN_UP ((grub_addr_t) addr, GRUB_MM_ALIGN);
+ 
+-- 
+2.53.0
+

--- a/SOURCES/0003-mm-grub_real_malloc-Make-small-allocs-comment-match-.patch
+++ b/SOURCES/0003-mm-grub_real_malloc-Make-small-allocs-comment-match-.patch
@@ -1,0 +1,35 @@
+From a847895a8d000bdf27ad4d4326f883a0eed769ca Mon Sep 17 00:00:00 2001
+From: Daniel Axtens <dja@axtens.net>
+Date: Thu, 25 Nov 2021 02:22:47 +1100
+Subject: [PATCH 3/3] mm: grub_real_malloc(): Make small allocs comment match
+ code
+
+Small allocations move the region's *first pointer. The comment
+says that this happens for allocations under 64K. The code says
+it's for allocations under 32K. Commit 45bf8b3a7549 changed the
+code intentionally: make the comment match.
+
+Fixes: 45bf8b3a7549 (* grub-core/kern/mm.c (grub_real_malloc): Decrease cut-off of moving the)
+
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ grub-core/kern/mm.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/grub-core/kern/mm.c b/grub-core/kern/mm.c
+index 6efabe92df0e..ac41cf4aab15 100644
+--- a/grub-core/kern/mm.c
++++ b/grub-core/kern/mm.c
+@@ -306,7 +306,7 @@ grub_real_malloc (grub_mm_header_t *first, grub_size_t n, grub_size_t align)
+ 	  /* Mark find as a start marker for next allocation to fasten it.
+ 	     This will have side effect of fragmenting memory as small
+ 	     pieces before this will be un-used.  */
+-	  /* So do it only for chunks under 64K.  */
++	  /* So do it only for chunks under 32K.  */
+ 	  if (n < (0x8000 >> GRUB_MM_ALIGN_LOG2)
+ 	      || *first == cur)
+ 	    *first = prev;
+-- 
+2.53.0
+

--- a/SOURCES/0004-mm-Document-grub_free.patch
+++ b/SOURCES/0004-mm-Document-grub_free.patch
@@ -1,0 +1,122 @@
+From 1f8d0b01738e49767d662d6426af3570a64565f0 Mon Sep 17 00:00:00 2001
+From: Daniel Axtens <dja@axtens.net>
+Date: Thu, 25 Nov 2021 02:22:48 +1100
+Subject: [PATCH 4/4] mm: Document grub_free()
+
+The grub_free() possesses a surprising number of quirks, and also
+uses single-letter variable names confusingly to iterate through
+the free list.
+
+Document what's going on.
+
+Use prev and cur to iterate over the free list.
+
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ grub-core/kern/mm.c | 63 +++++++++++++++++++++++++++++----------------
+ 1 file changed, 41 insertions(+), 22 deletions(-)
+
+diff --git a/grub-core/kern/mm.c b/grub-core/kern/mm.c
+index ac41cf4aab15..bec960c18e2b 100644
+--- a/grub-core/kern/mm.c
++++ b/grub-core/kern/mm.c
+@@ -446,54 +446,73 @@ grub_free (void *ptr)
+     }
+   else
+     {
+-      grub_mm_header_t q, s;
++      grub_mm_header_t cur, prev;
+ 
+ #if 0
+-      q = r->first;
++      cur = r->first;
+       do
+ 	{
+ 	  grub_printf ("%s:%d: q=%p, q->size=0x%x, q->magic=0x%x\n",
+-		       GRUB_FILE, __LINE__, q, q->size, q->magic);
+-	  q = q->next;
++		       GRUB_FILE, __LINE__, cur, cur->size, cur->magic);
++	  cur = cur->next;
+ 	}
+-      while (q != r->first);
++      while (cur != r->first);
+ #endif
+-
+-      for (s = r->first, q = s->next; q <= p || q->next >= p; s = q, q = s->next)
++      /* Iterate over all blocks in the free ring.
++       *
++       * The free ring is arranged from high addresses to low
++       * addresses, modulo wraparound.
++       *
++       * We are looking for a block with a higher address than p or
++       * whose next address is lower than p.
++       */
++      for (prev = r->first, cur = prev->next; cur <= p || cur->next >= p;
++	   prev = cur, cur = prev->next)
+ 	{
+-	  if (q->magic != GRUB_MM_FREE_MAGIC)
+-	    grub_fatal ("free magic is broken at %p: 0x%x", q, q->magic);
++	  if (cur->magic != GRUB_MM_FREE_MAGIC)
++	    grub_fatal ("free magic is broken at %p: 0x%x", cur, cur->magic);
+ 
+-	  if (q <= q->next && (q > p || q->next < p))
++	  /* Deal with wrap-around */
++	  if (cur <= cur->next && (cur > p || cur->next < p))
+ 	    break;
+ 	}
+ 
++      /* mark p as free and insert it between cur and cur->next */
+       p->magic = GRUB_MM_FREE_MAGIC;
+-      p->next = q->next;
+-      q->next = p;
++      p->next = cur->next;
++      cur->next = p;
+ 
++      /*
++       * If the block we are freeing can be merged with the next
++       * free block, do that.
++       */
+       if (p->next + p->next->size == p)
+ 	{
+ 	  p->magic = 0;
+ 
+ 	  p->next->size += p->size;
+-	  q->next = p->next;
++	  cur->next = p->next;
+ 	  p = p->next;
+ 	}
+ 
+-      r->first = q;
++      r->first = cur;
+ 
+-      if (q == p + p->size)
++      /* Likewise if can be merged with the preceeding free block */
++      if (cur == p + p->size)
+ 	{
+-	  q->magic = 0;
+-	  p->size += q->size;
+-	  if (q == s)
+-	    s = p;
+-	  s->next = p;
+-	  q = s;
++	  cur->magic = 0;
++	  p->size += cur->size;
++	  if (cur == prev)
++	    prev = p;
++	  prev->next = p;
++	  cur = prev;
+ 	}
+ 
+-      r->first = q;
++      /*
++       * Set r->first such that the just free()d block is tried first.
++       * (An allocation is tried from *first->next, and cur->next == p.)
++       */
++      r->first = cur;
+     }
+ }
+ 
+-- 
+2.53.0
+

--- a/SOURCES/0004-mm-Drop-unused-unloading-of-modules-on-OOM.patch
+++ b/SOURCES/0004-mm-Drop-unused-unloading-of-modules-on-OOM.patch
@@ -1,0 +1,82 @@
+From 139fd9b134a01e0b5fe0ebefafa7f48d1ffb6d60 Mon Sep 17 00:00:00 2001
+From: Patrick Steinhardt <ps@pks.im>
+Date: Thu, 21 Apr 2022 15:24:17 +1000
+Subject: [PATCH 4/4] mm: Drop unused unloading of modules on OOM
+
+In grub_memalign(), there's a commented section which would allow for
+unloading of unneeded modules in case where there is not enough free
+memory available to satisfy a request. Given that this code is never
+compiled in, let's remove it together with grub_dl_unload_unneeded().
+
+Signed-off-by: Patrick Steinhardt <ps@pks.im>
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+Tested-by: Patrick Steinhardt <ps@pks.im>
+---
+ grub-core/kern/dl.c | 20 --------------------
+ grub-core/kern/mm.c |  8 --------
+ include/grub/dl.h   |  1 -
+ 3 files changed, 29 deletions(-)
+
+diff --git a/grub-core/kern/dl.c b/grub-core/kern/dl.c
+index b1d3a103ec98..e447fd0fab4e 100644
+--- a/grub-core/kern/dl.c
++++ b/grub-core/kern/dl.c
+@@ -811,23 +811,3 @@ grub_dl_unload (grub_dl_t mod)
+   grub_free (mod);
+   return 1;
+ }
+-
+-/* Unload unneeded modules.  */
+-void
+-grub_dl_unload_unneeded (void)
+-{
+-  /* Because grub_dl_remove modifies the list of modules, this
+-     implementation is tricky.  */
+-  grub_dl_t p = grub_dl_head;
+-
+-  while (p)
+-    {
+-      if (grub_dl_unload (p))
+-	{
+-	  p = grub_dl_head;
+-	  continue;
+-	}
+-
+-      p = p->next;
+-    }
+-}
+diff --git a/grub-core/kern/mm.c b/grub-core/kern/mm.c
+index 43d4e609f6b0..e859772ab2e3 100644
+--- a/grub-core/kern/mm.c
++++ b/grub-core/kern/mm.c
+@@ -444,14 +444,6 @@ grub_memalign (grub_size_t align, grub_size_t size)
+       count++;
+       goto again;
+ 
+-#if 0
+-    case 1:
+-      /* Unload unneeded modules.  */
+-      grub_dl_unload_unneeded ();
+-      count++;
+-      goto again;
+-#endif
+-
+     default:
+       break;
+     }
+diff --git a/include/grub/dl.h b/include/grub/dl.h
+index d0f4115fe736..acb4d42327d7 100644
+--- a/include/grub/dl.h
++++ b/include/grub/dl.h
+@@ -203,7 +203,6 @@ grub_dl_t EXPORT_FUNC(grub_dl_load) (const char *name);
+ grub_dl_t grub_dl_load_core (void *addr, grub_size_t size);
+ grub_dl_t EXPORT_FUNC(grub_dl_load_core_noinit) (void *addr, grub_size_t size);
+ int EXPORT_FUNC(grub_dl_unload) (grub_dl_t mod);
+-extern void grub_dl_unload_unneeded (void);
+ extern int EXPORT_FUNC(grub_dl_ref) (grub_dl_t mod);
+ extern int EXPORT_FUNC(grub_dl_unref) (grub_dl_t mod);
+ extern int EXPORT_FUNC(grub_dl_ref_count) (grub_dl_t mod);
+-- 
+2.53.0
+

--- a/SOURCES/0005-kern-efi-mm-Reset-grub_mm_add_region_fn-after-ExitBo.patch
+++ b/SOURCES/0005-kern-efi-mm-Reset-grub_mm_add_region_fn-after-ExitBo.patch
@@ -1,0 +1,86 @@
+From 224aefd0574fa9325e5e0682b6b96f77084798ce Mon Sep 17 00:00:00 2001
+From: Ruihan Li <lrh2000@pku.edu.cn>
+Date: Mon, 16 Dec 2024 12:26:58 +0800
+Subject: [PATCH 5/5] kern/efi/mm: Reset grub_mm_add_region_fn after
+ ExitBootServices() call
+
+The EFI Boot Services can be used after ExitBootServices() call because
+the GRUB code still may allocate memory.
+
+An example call stack is:
+
+  grub_multiboot_boot
+    grub_multiboot2_make_mbi
+      grub_efi_finish_boot_services
+        b->exit_boot_services
+    normal_boot
+      grub_relocator32_boot
+        grub_relocator_alloc_chunk_align_safe
+          grub_relocator_alloc_chunk_align
+            grub_malloc
+              grub_memalign
+                grub_mm_add_region_fn
+                [= grub_efi_mm_add_regions]
+                  grub_efi_allocate_any_pages
+                    grub_efi_allocate_pages_real
+                      b->allocate_pages
+
+This can lead to confusing errors. After ExitBootServices() call
+b->allocate_pages may point to the NULL address resulting in something like:
+
+  !!!! X64 Exception Type - 01(#DB - Debug)  CPU Apic ID - 00000000 !!!!
+  RIP  - 000000000000201F, CS  - 0000000000000038, RFLAGS - 0000000000200002
+  RAX  - 000000007F9EE010, RCX - 0000000000000001, RDX - 0000000000000002
+  RBX  - 0000000000000006, RSP - 00000000001CFBEC, RBP - 0000000000000000
+  RSI  - 0000000000000000, RDI - 00000000FFFFFFFF
+  R8   - 0000000000000006, R9  - 000000007FEDFFB8, R10 - 0000000000000000
+  R11  - 0000000000000475, R12 - 0000000000000001, R13 - 0000000000000002
+  R14  - 00000000FFFFFFFF, R15 - 000000007E432C08
+  DS   - 0000000000000030, ES  - 0000000000000030, FS  - 0000000000000030
+  GS   - 0000000000000030, SS  - 0000000000000030
+  CR0  - 0000000080010033, CR2 - 0000000000000000, CR3 - 000000007FC01000
+  CR4  - 0000000000000668, CR8 - 0000000000000000
+  DR0  - 0000000000000000, DR1 - 0000000000000000, DR2 - 0000000000000000
+  DR3  - 0000000000000000, DR6 - 00000000FFFF0FF0, DR7 - 0000000000000400
+  GDTR - 000000007F9DE000 0000000000000047, LDTR - 0000000000000000
+  IDTR - 000000007F470018 0000000000000FFF,   TR - 0000000000000000
+  FXSAVE_STATE - 00000000001CF840
+
+Ideally we would like to avoid all memory allocations after exiting EFI
+Boot Services altogether but that requires significant code changes. This
+patch adds a simple workaround that resets grub_mm_add_region_fn to NULL
+after ExitBootServices() call, so:
+
+  - Memory allocations have a better chance of succeeding because grub_memalign()
+    will try to reclaim the disk cache if it sees a NULL in grub_mm_add_region_fn.
+
+  - At worst it will fail to allocate memory but it will explicitly tell users
+    that it's out of memory, which is still much better than the current
+    situation where it fails in a fairly random way and triggers a CPU fault.
+
+Signed-off-by: Ruihan Li <lrh2000@pku.edu.cn>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ grub-core/kern/efi/mm.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/grub-core/kern/efi/mm.c b/grub-core/kern/efi/mm.c
+index bc97ecd4799a..df238b165e06 100644
+--- a/grub-core/kern/efi/mm.c
++++ b/grub-core/kern/efi/mm.c
+@@ -297,6 +297,12 @@ grub_efi_finish_boot_services (grub_efi_uintn_t *outbuf_size, void *outbuf,
+   if (efi_desc_version)
+     *efi_desc_version = finish_desc_version;
+ 
++  /*
++   * We cannot request new memory regions from the EFI Boot Services anymore.
++   * FIXME: Can we completely avoid memory allocations after this?
++   */
++  grub_mm_add_region_fn = NULL;
++
+ #if defined (__i386__) || defined (__x86_64__)
+   if (is_apple)
+     stop_broadcom ();
+-- 
+2.53.0
+

--- a/SOURCES/0005-mm-Allow-dynamically-requesting-additional-memory-re.patch
+++ b/SOURCES/0005-mm-Allow-dynamically-requesting-additional-memory-re.patch
@@ -1,0 +1,133 @@
+From 887f98f0db43e33fba4ec1f85e42fae1185700bc Mon Sep 17 00:00:00 2001
+From: Patrick Steinhardt <ps@pks.im>
+Date: Thu, 21 Apr 2022 15:24:18 +1000
+Subject: [PATCH 5/5] mm: Allow dynamically requesting additional memory
+ regions
+
+Currently, all platforms will set up their heap on initialization of the
+platform code. While this works mostly fine, it poses some limitations
+on memory management on us. Most notably, allocating big chunks of
+memory in the gigabyte range would require us to pre-request this many
+bytes from the firmware and add it to the heap from the beginning on
+some platforms like EFI. As this isn't needed for most configurations,
+it is inefficient and may even negatively impact some usecases when,
+e.g., chainloading. Nonetheless, allocating big chunks of memory is
+required sometimes, where one example is the upcoming support for the
+Argon2 key derival function in LUKS2.
+
+In order to avoid pre-allocating big chunks of memory, this commit
+implements a runtime mechanism to add more pages to the system. When
+a given allocation cannot be currently satisfied, we'll call a given
+callback set up by the platform's own memory management subsystem,
+asking it to add a memory area with at least "n" bytes. If this
+succeeds, we retry searching for a valid memory region, which should
+now succeed.
+
+If this fails, we try asking for "n" bytes, possibly spread across
+multiple regions, in hopes that region merging means that we end up
+with enough memory for things to work out.
+
+Signed-off-by: Patrick Steinhardt <ps@pks.im>
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Tested-by: Stefan Berger <stefanb@linux.ibm.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+Tested-by: Patrick Steinhardt <ps@pks.im>
+---
+ grub-core/kern/mm.c | 30 ++++++++++++++++++++++++++++++
+ include/grub/mm.h   | 18 ++++++++++++++++++
+ 2 files changed, 48 insertions(+)
+
+diff --git a/grub-core/kern/mm.c b/grub-core/kern/mm.c
+index e859772ab2e3..75f6eacbeec8 100644
+--- a/grub-core/kern/mm.c
++++ b/grub-core/kern/mm.c
+@@ -28,6 +28,9 @@
+   - multiple regions may be used as free space. They may not be
+   contiguous.
+ 
++  - if existing regions are insufficient to satisfy an allocation, a new
++  region can be requested from firmware.
++
+   Regions are managed by a singly linked list, and the meta information is
+   stored in the beginning of each region. Space after the meta information
+   is used to allocate memory.
+@@ -81,6 +84,7 @@
+ 
+ 
+ grub_mm_region_t grub_mm_base;
++grub_mm_add_region_func_t grub_mm_add_region_fn;
+ 
+ /* Get a header from the pointer PTR, and set *P and *R to a pointer
+    to the header and a pointer to its region, respectively. PTR must
+@@ -444,6 +448,32 @@ grub_memalign (grub_size_t align, grub_size_t size)
+       count++;
+       goto again;
+ 
++    case 1:
++      /* Request additional pages, contiguous */
++      count++;
++
++      if (grub_mm_add_region_fn != NULL &&
++          grub_mm_add_region_fn (size, GRUB_MM_ADD_REGION_CONSECUTIVE) == GRUB_ERR_NONE)
++	goto again;
++
++      /* fallthrough  */
++
++    case 2:
++      /* Request additional pages, anything at all */
++      count++;
++
++      if (grub_mm_add_region_fn != NULL)
++        {
++          /*
++           * Try again even if this fails, in case it was able to partially
++           * satisfy the request
++           */
++          grub_mm_add_region_fn (size, GRUB_MM_ADD_REGION_NONE);
++          goto again;
++        }
++
++      /* fallthrough */
++
+     default:
+       break;
+     }
+diff --git a/include/grub/mm.h b/include/grub/mm.h
+index 44fde7cb9033..f3bf87fa0f9a 100644
+--- a/include/grub/mm.h
++++ b/include/grub/mm.h
+@@ -20,6 +20,7 @@
+ #ifndef GRUB_MM_H
+ #define GRUB_MM_H	1
+ 
++#include <grub/err.h>
+ #include <grub/types.h>
+ #include <grub/symbol.h>
+ #include <config.h>
+@@ -28,6 +29,23 @@
+ # define NULL	((void *) 0)
+ #endif
+ 
++#define GRUB_MM_ADD_REGION_NONE        0
++#define GRUB_MM_ADD_REGION_CONSECUTIVE (1 << 0)
++
++/*
++ * Function used to request memory regions of `grub_size_t` bytes. The second
++ * parameter is a bitfield of `GRUB_MM_ADD_REGION` flags.
++ */
++typedef grub_err_t (*grub_mm_add_region_func_t) (grub_size_t, unsigned int);
++
++/*
++ * Set this function pointer to enable adding memory-regions at runtime in case
++ * a memory allocation cannot be satisfied with existing regions.
++ */
++#ifndef GRUB_MACHINE_EMU
++extern grub_mm_add_region_func_t EXPORT_VAR(grub_mm_add_region_fn);
++#endif
++
+ void grub_mm_init_region (void *addr, grub_size_t size);
+ void *EXPORT_FUNC(grub_calloc) (grub_size_t nmemb, grub_size_t size);
+ void *EXPORT_FUNC(grub_malloc) (grub_size_t size);
+-- 
+2.53.0
+

--- a/SOURCES/0005-mm-Document-grub_mm_init_region.patch
+++ b/SOURCES/0005-mm-Document-grub_mm_init_region.patch
@@ -1,0 +1,75 @@
+From 246d69b7ea619fc1e77dcc5960e37aea45a9808c Mon Sep 17 00:00:00 2001
+From: Daniel Axtens <dja@axtens.net>
+Date: Thu, 25 Nov 2021 02:22:49 +1100
+Subject: [PATCH 5/5] mm: Document grub_mm_init_region()
+
+The grub_mm_init_region() does some things that seem magical, especially
+around region merging. Make it a bit clearer.
+
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ grub-core/kern/mm.c | 31 ++++++++++++++++++++++++++++++-
+ 1 file changed, 30 insertions(+), 1 deletion(-)
+
+diff --git a/grub-core/kern/mm.c b/grub-core/kern/mm.c
+index bec960c18e2b..c68691752312 100644
+--- a/grub-core/kern/mm.c
++++ b/grub-core/kern/mm.c
+@@ -128,23 +128,52 @@ grub_mm_init_region (void *addr, grub_size_t size)
+   if (((grub_addr_t) addr + 0x1000) > ~(grub_addr_t) size)
+     size = ((grub_addr_t) -0x1000) - (grub_addr_t) addr;
+ 
++  /* Attempt to merge this region with every existing region */
+   for (p = &grub_mm_base, q = *p; q; p = &(q->next), q = *p)
++    /*
++     * Is the new region immediately below an existing region? That
++     * is, is the address of the memory we're adding now (addr) + size
++     * of the memory we're adding (size) + the bytes we couldn't use
++     * at the start of the region we're considering (q->pre_size)
++     * equal to the address of q? In other words, does the memory
++     * looks like this?
++     *
++     * addr                          q
++     *   |----size-----|-q->pre_size-|<q region>|
++     */
+     if ((grub_uint8_t *) addr + size + q->pre_size == (grub_uint8_t *) q)
+       {
++	/*
++	 * Yes, we can merge the memory starting at addr into the
++	 * existing region from below. Align up addr to GRUB_MM_ALIGN
++	 * so that our new region has proper alignment.
++	 */
+ 	r = (grub_mm_region_t) ALIGN_UP ((grub_addr_t) addr, GRUB_MM_ALIGN);
++	/* Copy the region data across */
+ 	*r = *q;
++	/* Consider all the new size as pre-size */
+ 	r->pre_size += size;
+-	
++
++	/*
++	 * If we have enough pre-size to create a block, create a
++	 * block with it. Mark it as allocated and pass it to
++	 * grub_free (), which will sort out getting it into the free
++	 * list.
++	 */
+ 	if (r->pre_size >> GRUB_MM_ALIGN_LOG2)
+ 	  {
+ 	    h = (grub_mm_header_t) (r + 1);
++	    /* block size is pre-size converted to cells */
+ 	    h->size = (r->pre_size >> GRUB_MM_ALIGN_LOG2);
+ 	    h->magic = GRUB_MM_ALLOC_MAGIC;
++	    /* region size grows by block size converted back to bytes */
+ 	    r->size += h->size << GRUB_MM_ALIGN_LOG2;
++	    /* adjust pre_size to be accurate */
+ 	    r->pre_size &= (GRUB_MM_ALIGN - 1);
+ 	    *p = r;
+ 	    grub_free (h + 1);
+ 	  }
++	/* Replace the old region with the new region */
+ 	*p = r;
+ 	return;
+       }
+-- 
+2.53.0
+

--- a/SOURCES/0006-kern-efi-mm-Always-request-a-fixed-number-of-pages-o.patch
+++ b/SOURCES/0006-kern-efi-mm-Always-request-a-fixed-number-of-pages-o.patch
@@ -1,0 +1,106 @@
+From 938c3760b8c0fca759140be48307179b50107ff6 Mon Sep 17 00:00:00 2001
+From: Patrick Steinhardt <ps@pks.im>
+Date: Thu, 21 Apr 2022 15:24:19 +1000
+Subject: [PATCH 6/6] kern/efi/mm: Always request a fixed number of pages on
+ init
+
+When initializing the EFI memory subsystem, we will by default request
+a quarter of the available memory, bounded by a minimum/maximum value.
+Given that we're about to extend the EFI memory system to dynamically
+request additional pages from the firmware as required, this scaling of
+requested memory based on available memory will not make a lot of sense
+anymore.
+
+Remove this logic as a preparatory patch such that we'll instead defer
+to the runtime memory allocator. Note that ideally, we'd want to change
+this after dynamic requesting of pages has been implemented for the EFI
+platform. But because we'll need to split up initialization of the
+memory subsystem and the request of pages from the firmware, we'd have
+to duplicate quite some logic at first only to remove it afterwards
+again. This seems quite pointless, so we instead have patches slightly
+out of order.
+
+Signed-off-by: Patrick Steinhardt <ps@pks.im>
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+Tested-by: Patrick Steinhardt <ps@pks.im>
+---
+ grub-core/kern/efi/mm.c | 35 +++--------------------------------
+ 1 file changed, 3 insertions(+), 32 deletions(-)
+
+diff --git a/grub-core/kern/efi/mm.c b/grub-core/kern/efi/mm.c
+index d8e4114541a4..0bccd24f304f 100644
+--- a/grub-core/kern/efi/mm.c
++++ b/grub-core/kern/efi/mm.c
+@@ -38,9 +38,8 @@
+    a multiplier of 4KB.  */
+ #define MEMORY_MAP_SIZE	0x3000
+ 
+-/* The minimum and maximum heap size for GRUB itself.  */
+-#define MIN_HEAP_SIZE	0x100000
+-#define MAX_HEAP_SIZE	(1600 * 0x100000)
++/* The default heap size for GRUB itself in bytes.  */
++#define DEFAULT_HEAP_SIZE	0x100000
+ 
+ static void *finish_mmap_buf = 0;
+ static grub_efi_uintn_t finish_mmap_size = 0;
+@@ -478,23 +477,6 @@ filter_memory_map (grub_efi_memory_descriptor_t *memory_map,
+   return filtered_desc;
+ }
+ 
+-/* Return the total number of pages.  */
+-static grub_efi_uint64_t
+-get_total_pages (grub_efi_memory_descriptor_t *memory_map,
+-		 grub_efi_uintn_t desc_size,
+-		 grub_efi_memory_descriptor_t *memory_map_end)
+-{
+-  grub_efi_memory_descriptor_t *desc;
+-  grub_efi_uint64_t total = 0;
+-
+-  for (desc = memory_map;
+-       desc < memory_map_end;
+-       desc = NEXT_MEMORY_DESCRIPTOR (desc, desc_size))
+-    total += desc->num_pages;
+-
+-  return total;
+-}
+-
+ /* Add memory regions.  */
+ static void
+ add_memory_regions (grub_efi_memory_descriptor_t *memory_map,
+@@ -583,8 +565,6 @@ grub_efi_mm_init (void)
+   grub_efi_memory_descriptor_t *filtered_memory_map_end;
+   grub_efi_uintn_t map_size;
+   grub_efi_uintn_t desc_size;
+-  grub_efi_uint64_t total_pages;
+-  grub_efi_uint64_t required_pages;
+   int mm_status;
+ 
+   /* Prepare a memory region to store two memory maps.  */
+@@ -624,22 +604,13 @@ grub_efi_mm_init (void)
+   filtered_memory_map_end = filter_memory_map (memory_map, filtered_memory_map,
+ 					       desc_size, memory_map_end);
+ 
+-  /* By default, request a quarter of the available memory.  */
+-  total_pages = get_total_pages (filtered_memory_map, desc_size,
+-				 filtered_memory_map_end);
+-  required_pages = (total_pages >> 2);
+-  if (required_pages < BYTES_TO_PAGES (MIN_HEAP_SIZE))
+-    required_pages = BYTES_TO_PAGES (MIN_HEAP_SIZE);
+-  else if (required_pages > BYTES_TO_PAGES (MAX_HEAP_SIZE))
+-    required_pages = BYTES_TO_PAGES (MAX_HEAP_SIZE);
+-
+   /* Sort the filtered descriptors, so that GRUB can allocate pages
+      from smaller regions.  */
+   sort_memory_map (filtered_memory_map, desc_size, filtered_memory_map_end);
+ 
+   /* Allocate memory regions for GRUB's memory management.  */
+   add_memory_regions (filtered_memory_map, desc_size,
+-		      filtered_memory_map_end, required_pages);
++		      filtered_memory_map_end, BYTES_TO_PAGES (DEFAULT_HEAP_SIZE));
+ 
+ #if 0
+   /* For debug.  */
+-- 
+2.53.0
+

--- a/SOURCES/0007-kern-efi-mm-Extract-function-to-add-memory-regions.patch
+++ b/SOURCES/0007-kern-efi-mm-Extract-function-to-add-memory-regions.patch
@@ -1,0 +1,86 @@
+From 96a7ea29e3cb61b6c2302e260e8e6a6117e17fa3 Mon Sep 17 00:00:00 2001
+From: Patrick Steinhardt <ps@pks.im>
+Date: Thu, 21 Apr 2022 15:24:20 +1000
+Subject: [PATCH 7/7] kern/efi/mm: Extract function to add memory regions
+
+In preparation of support for runtime-allocating additional memory
+region, this patch extracts the function to retrieve the EFI memory
+map and add a subset of it to GRUB's own memory regions.
+
+Signed-off-by: Patrick Steinhardt <ps@pks.im>
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+Tested-by: Patrick Steinhardt <ps@pks.im>
+---
+ grub-core/kern/efi/mm.c | 21 +++++++++++++++------
+ 1 file changed, 15 insertions(+), 6 deletions(-)
+
+diff --git a/grub-core/kern/efi/mm.c b/grub-core/kern/efi/mm.c
+index 0bccd24f304f..09c03b83fcd6 100644
+--- a/grub-core/kern/efi/mm.c
++++ b/grub-core/kern/efi/mm.c
+@@ -556,8 +556,8 @@ print_memory_map (grub_efi_memory_descriptor_t *memory_map,
+ }
+ #endif
+ 
+-void
+-grub_efi_mm_init (void)
++static grub_err_t
++grub_efi_mm_add_regions (grub_size_t required_bytes)
+ {
+   grub_efi_memory_descriptor_t *memory_map;
+   grub_efi_memory_descriptor_t *memory_map_end;
+@@ -570,7 +570,7 @@ grub_efi_mm_init (void)
+   /* Prepare a memory region to store two memory maps.  */
+   memory_map = grub_efi_allocate_any_pages (2 * BYTES_TO_PAGES (MEMORY_MAP_SIZE));
+   if (! memory_map)
+-    grub_fatal ("cannot allocate memory");
++    return grub_error (GRUB_ERR_OUT_OF_MEMORY, "cannot allocate memory for memory map");
+ 
+   /* Obtain descriptors for available memory.  */
+   map_size = MEMORY_MAP_SIZE;
+@@ -588,14 +588,14 @@ grub_efi_mm_init (void)
+ 
+       memory_map = grub_efi_allocate_any_pages (2 * BYTES_TO_PAGES (map_size));
+       if (! memory_map)
+-	grub_fatal ("cannot allocate memory");
++	return grub_error (GRUB_ERR_OUT_OF_MEMORY, "cannot allocate memory for new memory map");
+ 
+       mm_status = grub_efi_get_memory_map (&map_size, memory_map, 0,
+ 					   &desc_size, 0);
+     }
+ 
+   if (mm_status < 0)
+-    grub_fatal ("cannot get memory map");
++    return grub_error (GRUB_ERR_OUT_OF_MEMORY, "error fetching memory map from EFI");
+ 
+   memory_map_end = NEXT_MEMORY_DESCRIPTOR (memory_map, map_size);
+ 
+@@ -610,7 +610,7 @@ grub_efi_mm_init (void)
+ 
+   /* Allocate memory regions for GRUB's memory management.  */
+   add_memory_regions (filtered_memory_map, desc_size,
+-		      filtered_memory_map_end, BYTES_TO_PAGES (DEFAULT_HEAP_SIZE));
++		      filtered_memory_map_end, BYTES_TO_PAGES (required_bytes));
+ 
+ #if 0
+   /* For debug.  */
+@@ -628,6 +628,15 @@ grub_efi_mm_init (void)
+   /* Release the memory maps.  */
+   grub_efi_free_pages ((grub_addr_t) memory_map,
+ 		       2 * BYTES_TO_PAGES (MEMORY_MAP_SIZE));
++
++  return GRUB_ERR_NONE;
++}
++
++void
++grub_efi_mm_init (void)
++{
++  if (grub_efi_mm_add_regions (DEFAULT_HEAP_SIZE) != GRUB_ERR_NONE)
++    grub_fatal ("%s", grub_errmsg);
+ }
+ 
+ #if defined (__aarch64__) || defined (__arm__) || defined (__riscv)
+-- 
+2.53.0
+

--- a/SOURCES/0008-kern-efi-mm-Pass-up-errors-from-add_memory_regions.patch
+++ b/SOURCES/0008-kern-efi-mm-Pass-up-errors-from-add_memory_regions.patch
@@ -1,0 +1,82 @@
+From 15a015698921240adc1ac266a3b5bc5fcbd81521 Mon Sep 17 00:00:00 2001
+From: Patrick Steinhardt <ps@pks.im>
+Date: Thu, 21 Apr 2022 15:24:21 +1000
+Subject: [PATCH 8/8] kern/efi/mm: Pass up errors from add_memory_regions()
+
+The function add_memory_regions() is currently only called on system
+initialization to allocate a fixed amount of pages. As such, it didn't
+need to return any errors: in case it failed, we cannot proceed anyway.
+This will change with the upcoming support for requesting more memory
+from the firmware at runtime, where it doesn't make sense anymore to
+fail hard.
+
+Refactor the function to return an error to prepare for this. Note that
+this does not change the behaviour when initializing the memory system
+because grub_efi_mm_init() knows to call grub_fatal() in case
+grub_efi_mm_add_regions() returns an error.
+
+Signed-off-by: Patrick Steinhardt <ps@pks.im>
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+Tested-by: Patrick Steinhardt <ps@pks.im>
+diff --git a/grub-core/kern/efi/mm.c b/grub-core/kern/efi/mm.c
+index f1513455703d..b9d928b766b2 100644
+--- a/grub-core/kern/efi/mm.c
++++ b/grub-core/kern/efi/mm.c
+@@ -478,7 +478,7 @@ filter_memory_map (grub_efi_memory_descriptor_t *memory_map,
+ }
+ 
+ /* Add memory regions.  */
+-static void
++static grub_err_t
+ add_memory_regions (grub_efi_memory_descriptor_t *memory_map,
+ 		    grub_efi_uintn_t desc_size,
+ 		    grub_efi_memory_descriptor_t *memory_map_end,
+@@ -506,9 +506,9 @@ add_memory_regions (grub_efi_memory_descriptor_t *memory_map,
+ 					   GRUB_EFI_ALLOCATE_ADDRESS,
+ 					   GRUB_EFI_LOADER_CODE);      
+       if (! addr)
+-	grub_fatal ("cannot allocate conventional memory %p with %u pages",
+-		    (void *) ((grub_addr_t) start),
+-		    (unsigned) pages);
++	return grub_error (GRUB_ERR_OUT_OF_MEMORY,
++			    "Memory starting at %p (%u pages) marked as free, but EFI would not allocate",
++			    (void *) ((grub_addr_t) start), (unsigned) pages);
+ 
+       grub_mm_init_region (addr, PAGES_TO_BYTES (pages));
+ 
+@@ -518,7 +518,11 @@ add_memory_regions (grub_efi_memory_descriptor_t *memory_map,
+     }
+ 
+   if (required_pages > 0)
+-    grub_fatal ("too little memory");
++    return grub_error (GRUB_ERR_OUT_OF_MEMORY,
++                       "could not allocate all requested memory: %" PRIuGRUB_UINT64_T " pages still required after iterating EFI memory map",
++                       required_pages);
++
++  return GRUB_ERR_NONE;
+ }
+ 
+ void
+@@ -565,6 +569,7 @@ grub_efi_mm_add_regions (grub_size_t required_bytes)
+   grub_efi_memory_descriptor_t *filtered_memory_map_end;
+   grub_efi_uintn_t map_size;
+   grub_efi_uintn_t desc_size;
++  grub_err_t err;
+   int mm_status;
+ 
+   /* Prepare a memory region to store two memory maps.  */
+@@ -609,8 +614,11 @@ grub_efi_mm_add_regions (grub_size_t required_bytes)
+   sort_memory_map (filtered_memory_map, desc_size, filtered_memory_map_end);
+ 
+   /* Allocate memory regions for GRUB's memory management.  */
+-  add_memory_regions (filtered_memory_map, desc_size,
+-		      filtered_memory_map_end, BYTES_TO_PAGES (required_bytes));
++  err = add_memory_regions (filtered_memory_map, desc_size,
++			    filtered_memory_map_end,
++			    BYTES_TO_PAGES (required_bytes));
++  if (err != GRUB_ERR_NONE)
++    return err;
+ 
+ #if 0
+   /* For debug.  */

--- a/SOURCES/0009-kern-efi-mm-Implement-runtime-addition-of-pages.patch
+++ b/SOURCES/0009-kern-efi-mm-Implement-runtime-addition-of-pages.patch
@@ -1,0 +1,77 @@
+From 1df2934822df4c1170dde069d97cfbf7a9572bba Mon Sep 17 00:00:00 2001
+From: Patrick Steinhardt <ps@pks.im>
+Date: Thu, 21 Apr 2022 15:24:22 +1000
+Subject: [PATCH 9/9] kern/efi/mm: Implement runtime addition of pages
+
+Adjust the interface of grub_efi_mm_add_regions() to take a set of
+GRUB_MM_ADD_REGION_* flags, which most notably is currently only the
+GRUB_MM_ADD_REGION_CONSECUTIVE flag. This allows us to set the function
+up as callback for the memory subsystem and have it call out to us in
+case there's not enough pages available in the current heap.
+
+Signed-off-by: Patrick Steinhardt <ps@pks.im>
+Signed-off-by: Daniel Axtens <dja@axtens.net>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+Tested-by: Patrick Steinhardt <ps@pks.im>
+---
+ grub-core/kern/efi/mm.c | 15 +++++++++++----
+ 1 file changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/grub-core/kern/efi/mm.c b/grub-core/kern/efi/mm.c
+index 0e7eb1cc16dd..d290c9a76270 100644
+--- a/grub-core/kern/efi/mm.c
++++ b/grub-core/kern/efi/mm.c
+@@ -482,7 +482,8 @@ static grub_err_t
+ add_memory_regions (grub_efi_memory_descriptor_t *memory_map,
+ 		    grub_efi_uintn_t desc_size,
+ 		    grub_efi_memory_descriptor_t *memory_map_end,
+-		    grub_efi_uint64_t required_pages)
++		    grub_efi_uint64_t required_pages,
++		    unsigned int flags)
+ {
+   grub_efi_memory_descriptor_t *desc;
+ 
+@@ -496,6 +497,10 @@ add_memory_regions (grub_efi_memory_descriptor_t *memory_map,
+ 
+       start = desc->physical_start;
+       pages = desc->num_pages;
++
++      if (pages < required_pages && (flags & GRUB_MM_ADD_REGION_CONSECUTIVE))
++	continue;
++
+       if (pages > required_pages)
+ 	{
+ 	  start += PAGES_TO_BYTES (pages - required_pages);
+@@ -561,7 +566,7 @@ print_memory_map (grub_efi_memory_descriptor_t *memory_map,
+ #endif
+ 
+ static grub_err_t
+-grub_efi_mm_add_regions (grub_size_t required_bytes)
++grub_efi_mm_add_regions (grub_size_t required_bytes, unsigned int flags)
+ {
+   grub_efi_memory_descriptor_t *memory_map;
+   grub_efi_memory_descriptor_t *memory_map_end;
+@@ -616,7 +621,8 @@ grub_efi_mm_add_regions (grub_size_t required_bytes)
+   /* Allocate memory regions for GRUB's memory management.  */
+   err = add_memory_regions (filtered_memory_map, desc_size,
+ 			    filtered_memory_map_end,
+-			    BYTES_TO_PAGES (required_bytes));
++			    BYTES_TO_PAGES (required_bytes),
++			    flags);
+   if (err != GRUB_ERR_NONE)
+     return err;
+ 
+@@ -643,8 +649,9 @@ grub_efi_mm_add_regions (grub_size_t required_bytes)
+ void
+ grub_efi_mm_init (void)
+ {
+-  if (grub_efi_mm_add_regions (DEFAULT_HEAP_SIZE) != GRUB_ERR_NONE)
++  if (grub_efi_mm_add_regions (DEFAULT_HEAP_SIZE, GRUB_MM_ADD_REGION_NONE) != GRUB_ERR_NONE)
+     grub_fatal ("%s", grub_errmsg);
++  grub_mm_add_region_fn = grub_efi_mm_add_regions;
+ }
+ 
+ #if defined (__aarch64__) || defined (__arm__) || defined (__riscv)
+-- 
+2.53.0
+

--- a/SPECS/grub.spec
+++ b/SPECS/grub.spec
@@ -1,7 +1,14 @@
-%global package_speccommit fc34746fb50a39e9650f459538e08b6ea78a3fda
+%global package_speccommit 41135ff309bc7091fd8f335637427dc79395b6a6
 %global usver 2.06
-%global xsver 4.0.2
+%global xsver 4.0.5
 %global xsrel %{xsver}%{?xscount}%{?xshash}
+# This package calls binutils components directly and would need to pass
+# in flags to enable the LTO plugins
+# Disable LTO
+%global _lto_cflags %{nil}
+
+%undefine _hardened_build
+
 %global package_srccommit grub-2.06
 
 # Modules always contain just 32-bit code
@@ -57,13 +64,35 @@ URL:            http://www.gnu.org/software/grub/
 Obsoletes:      grub < 1:0.98
 Source0: grub-2.06.tar.gz
 Source1: gnulib.tar.gz
-Patch0: wait-before-drain.patch
-Patch1: 0001-lib-relocator-always-enforce-the-requested-alignment.patch
+Patch0: 0001-mm-Document-GRUB-internal-memory-management-structur.patch
+Patch1: 0002-mm-Clarify-grub_real_malloc.patch
+Patch2: 0003-mm-grub_real_malloc-Make-small-allocs-comment-match-.patch
+Patch3: 0004-mm-Document-grub_free.patch
+Patch4: 0005-mm-Document-grub_mm_init_region.patch
+Patch5: 0001-mm-Assert-that-we-preserve-header-vs-region-alignmen.patch
+Patch6: 0002-mm-When-adding-a-region-merge-with-region-after-as-w.patch
+Patch7: 0003-mm-Debug-support-for-region-operations.patch
+Patch8: 0004-mm-Drop-unused-unloading-of-modules-on-OOM.patch
+Patch9: 0005-mm-Allow-dynamically-requesting-additional-memory-re.patch
+Patch10: 0006-kern-efi-mm-Always-request-a-fixed-number-of-pages-o.patch
+Patch11: 0007-kern-efi-mm-Extract-function-to-add-memory-regions.patch
+Patch12: 0008-kern-efi-mm-Pass-up-errors-from-add_memory_regions.patch
+Patch13: 0009-kern-efi-mm-Implement-runtime-addition-of-pages.patch
+Patch14: 0001-efi-Increase-default-memory-allocation-to-32-MiB.patch
+Patch15: 0001-kern-efi-mm-Detect-calls-to-grub_efi_drop_alloc-with.patch
+Patch16: 0001-lib-relocator-Always-enforce-the-requested-alignment.patch
+Patch17: 0001-kern-efi-mm-Fix-use-after-free-in-finish-boot-servic.patch
+Patch18: 0002-kern-efi-mm-Change-grub_efi_mm_add_regions-to-keep-t.patch
+Patch19: 0003-kern-efi-mm-Change-grub_efi_allocate_pages_real-to-c.patch
+Patch20: 0005-kern-efi-mm-Reset-grub_mm_add_region_fn-after-ExitBo.patch
+Patch21: wait-before-drain.patch
 
+%if 0%{?xenserver} < 9
 BuildRequires:  devtoolset-10-gcc
+%endif
 BuildRequires:  flex bison binutils python
 BuildRequires:  ncurses-devel xz-devel
-BuildRequires:  freetype-devel libusb-devel
+BuildRequires:  libusb-devel
 %ifarch %{sparc} x86_64
 # sparc builds need 64 bit glibc-devel - also for 32 bit userland
 BuildRequires:  %{_exec_prefix}/lib64/crt1.o glibc-static
@@ -71,8 +100,8 @@ BuildRequires:  %{_exec_prefix}/lib64/crt1.o glibc-static
 # ppc64 builds need the ppc crt1.o
 BuildRequires:  %{_exec_prefix}/lib/crt1.o glibc-static
 %endif
-BuildRequires:  autoconf automake autogen device-mapper-devel
-BuildRequires:  freetype-devel gettext-devel git
+BuildRequires:  autoconf automake device-mapper-devel
+BuildRequires:  gettext-devel git
 BuildRequires:  texinfo
 BuildRequires:  help2man
 %{?_cov_buildrequires}
@@ -124,14 +153,16 @@ cp -a . ../%{name}-efi-%{version}
 %{?_cov_prepare}
 
 %build
+%if 0%{?xenserver} < 9
 . /opt/rh/devtoolset-10/enable
+%endif
 
 %ifarch %{efiarchs}
 pushd ../%{name}-efi-%{version}
 ./bootstrap
 %configure \
     CFLAGS="$(echo $RPM_OPT_FLAGS | sed \
-        -e 's/-O.//g' \
+        -e 's/-O. /-Os /g' \
         -e 's/-fstack-protector[[:alpha:]-]\+//g' \
         -e 's/-fstack-protector//g' \
         -e 's/--param=ssp-buffer-size=4//g' \
@@ -139,6 +170,7 @@ pushd ../%{name}-efi-%{version}
         -e 's/-fexceptions//g' \
         -e 's/-fasynchronous-unwind-tables//g' \
         -e 's/-m64//g' \
+        -e 's/-fcf-protection//g' \
         -e 's/^/ -fno-strict-aliasing /' \
         -e 's/^/ -fno-stack-protector /' \
                 )"                                              \
@@ -173,7 +205,7 @@ popd
 %endif
 %configure \
     CFLAGS="$(echo $RPM_OPT_FLAGS | sed \
-        -e 's/-O.//g' \
+        -e 's/-O. /-Os /g' \
         -e 's/-fstack-protector[[:alpha:]-]\+//g' \
         -e 's/-fstack-protector//g' \
         -e 's/--param=ssp-buffer-size=4//g' \
@@ -182,6 +214,7 @@ popd
         -e 's/-m64//g' \
         -e 's/-fasynchronous-unwind-tables//g' \
         -e 's/-mcpu=power7/-mcpu=power6/g' \
+        -e 's/-fcf-protection//g' \
         -e 's/^/ -fno-strict-aliasing /' )" \
     TARGET_LDFLAGS=-static \
         --with-platform=%{platform} \
@@ -367,7 +400,6 @@ fi
 %{_bindir}/%{name}-glue-efi
 %{_bindir}/%{name}-kbdcomp
 %{_bindir}/%{name}-menulst2cfg
-%{_bindir}/%{name}-mkfont
 %{_bindir}/%{name}-mkimage
 %{_bindir}/%{name}-mklayout
 %{_bindir}/%{name}-mknetdir
@@ -401,6 +433,15 @@ fi
 %{?_cov_results_package}
 
 %changelog
+* Fri Apr 17 2026 Ross Lagerwall <ross.lagerwall@citrix.com> - 2.06-4.0.5
+- CA-424431: Fix a rare out-of-memory error
+
+* Thu May 30 2024 Deli Zhang <deli.zhang@cloud.com> - 2.06-4.0.4
+- CP-46111: Remove build require freetype-devel
+
+* Thu Apr 11 2024 Frediano Ziglio <frediano.ziglio@cloud.com> - 2.06-4.0.3
+- CP-47745: compatibilities for XS9, optimize back some code
+
 * Wed May 17 2023 Ross Lagerwall <ross.lagerwall@citrix.com> - 2.06-4.0.2
 - HP-1153: always enforce requested allocation alignment
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3328

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Sync with upstream

#### Release Target

- [ ] We already defined a release target with the release team.
- [x] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

next

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Sync with upstream, Fix a rare out-of-memory error

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

grub install is used in:
https://github.com/xcp-ng/host-installer/blob/ydi/10.10.38-8.3/backend.py#L1304



#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->



<!-- Add links to the documentation update PRs if/when they are created. -->



---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

none yet i am considering some:

- [ ] regression tests on hosts (nested)  ? bios and uefi
- [ ] try /opt/xensource/bin/updategrub.py ?


### BIOS

```
yum install --enablerepo xcp-ng-pcoval2  grub
time grub-install /dev/sda
reboot
yum install  kernel-alt # kernel-alt.x86_64 0:4.19.322+1-1.xcpng8.3
#| Adding 'XCP-ng kernel-alt 4.19.322+1' as grub entry #5 # <- This is /opt/xensource/bin/updategrub.py 
reboot # select alt
yum reinstall  kernel # kernel-4.19.19-8.0.46.5.xcpng8.3.x86_64.rpm 
# No grub involved here? 
```
I assume because conf file /etc/grub.cfg point to /boot/vmlinuz-4.19-xen which should be stable over the release ? right ? something set by installer ? @ydirson 

Also the conf file is generated with:

https://github.com/xcp-ng/host-installer/blob/ydi/10.10.38-8.3/backend.py#L1166




#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

- [ ] test along candidate installer (when ready)


#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

I assume reboot will be enough for testing

#### What tests have been or will be added to CI for this change? If none, explain why.

It would be nice to test this along the installer tests, any opinion @ydirson @vxgmichel ?

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
